### PR TITLE
Include is unused and causes C++11 error when compiled with some 3rd par...

### DIFF
--- a/deflect/Event.h
+++ b/deflect/Event.h
@@ -40,7 +40,9 @@
 #ifndef DEFLECT_EVENT_H
 #define DEFLECT_EVENT_H
 
-#include <cstdint>
+#ifdef _MSC_VER
+#  include <stdint.h>
+#endif
 
 #include <deflect/api.h>
 #include <deflect/types.h>


### PR DESCRIPTION
Include is unused and causes C++11 error when compiled with some 3rd party applications
