### PR TITLE
QmlStreamer: New 'streamname' command line option

### DIFF
--- a/apps/QmlStreamer/main.cpp
+++ b/apps/QmlStreamer/main.cpp
@@ -38,19 +38,29 @@ int main( int argc, char** argv )
                                       "qrc:/qml/gui.qml" );
     parser.addOption( qmlFileOption );
 
-    QCommandLineOption streamHostOption( "host", "Stream hostname", "hostname",
-                                         "localhost" );
+    QCommandLineOption streamHostOption( "host", "Stream target hostname "
+                                                 "(default: localhost)",
+                                         "hostname", "localhost" );
     parser.addOption( streamHostOption );
+
+    // note: the 'name' command line option is already taken by QCoreApplication
+    QCommandLineOption streamNameOption( "streamname", "Stream name (default: "
+                                                 "Qml's root objectName "
+                                                 "property or 'QmlStreamer')",
+                                         "name" );
+    parser.addOption( streamNameOption );
 
     parser.process( app );
 
     const QString qmlFile = parser.value( qmlFileOption );
     const QString streamHost = parser.value( streamHostOption );
+    const QString streamName = parser.value( streamNameOption );
 
     try
     {
         QScopedPointer< deflect::qt::QmlStreamer > streamer(
-             new deflect::qt::QmlStreamer( qmlFile, streamHost.toStdString( )));
+             new deflect::qt::QmlStreamer( qmlFile, streamHost.toStdString(),
+                                           streamName.toStdString( )));
         return app.exec();
     }
     catch( const std::runtime_error& exception )

--- a/deflect/qt/QmlStreamer.cpp
+++ b/deflect/qt/QmlStreamer.cpp
@@ -46,8 +46,9 @@ namespace qt
 {
 
 QmlStreamer::QmlStreamer( const QString& qmlFile,
-                          const std::string& streamHost )
-    : _impl( new Impl( qmlFile, streamHost ))
+                          const std::string& streamHost,
+                          const std::string& streamName )
+    : _impl( new Impl( qmlFile, streamHost, streamName ))
 {
 }
 

--- a/deflect/qt/QmlStreamer.h
+++ b/deflect/qt/QmlStreamer.h
@@ -68,9 +68,13 @@ public:
      *
      * @param qmlFile URL to QML file to load
      * @param streamHost hostname of the Deflect server
+     * @param streamName name of the Deflect stream (optional). Setting this
+     *        value overrides the 'objectName' property of the root QML item.
+     *        If neither is provided, "QmlStreamer" is used instead.
      */
     DEFLECTQT_API QmlStreamer( const QString& qmlFile,
-                               const std::string& streamHost );
+                               const std::string& streamHost,
+                               const std::string& streamName = std::string( ));
 
     DEFLECTQT_API ~QmlStreamer();
 

--- a/deflect/qt/QmlStreamerImpl.cpp
+++ b/deflect/qt/QmlStreamerImpl.cpp
@@ -51,6 +51,10 @@
 #include <QQuickRenderControl>
 #include <QQuickWindow>
 
+namespace
+{
+const std::string DEFAULT_STREAM_NAME( "QmlStreamer" );
+}
 
 class RenderControl : public QQuickRenderControl
 {
@@ -75,7 +79,8 @@ namespace deflect
 namespace qt
 {
 
-QmlStreamer::Impl::Impl( const QString& qmlFile, const std::string& streamHost )
+QmlStreamer::Impl::Impl( const QString& qmlFile, const std::string& streamHost,
+                         const std::string& streamName )
     : QWindow()
     , _context( new QOpenGLContext )
     , _offscreenSurface( new QOffscreenSurface )
@@ -92,6 +97,7 @@ QmlStreamer::Impl::Impl( const QString& qmlFile, const std::string& streamHost )
     , _eventHandler( nullptr )
     , _streaming( false )
     , _streamHost( streamHost )
+    , _streamName( streamName )
 {
     setSurfaceType( QSurface::OpenGLSurface );
 
@@ -321,14 +327,19 @@ bool QmlStreamer::Impl::_setupRootItem()
     return true;
 }
 
+std::string QmlStreamer::Impl::_getDeflectStreamName() const
+{
+    if( !_streamName.empty( ))
+        return _streamName;
+
+    const std::string streamName = _rootItem->objectName().toStdString();
+    return streamName.empty() ? DEFAULT_STREAM_NAME : streamName;
+}
+
 bool QmlStreamer::Impl::_setupDeflectStream()
 {
     if( !_stream )
-    {
-        const std::string streamName = _rootItem->objectName().toStdString();
-        _stream = new Stream( streamName.empty() ? "QmlStreamer" : streamName,
-                              _streamHost );
-    }
+        _stream = new Stream( _getDeflectStreamName(), _streamHost );
 
     if( !_stream->isConnected( ))
         return false;

--- a/deflect/qt/QmlStreamerImpl.h
+++ b/deflect/qt/QmlStreamerImpl.h
@@ -70,7 +70,8 @@ class QmlStreamer::Impl : public QWindow
     Q_OBJECT
 
 public:
-    Impl( const QString& qmlFile, const std::string& streamHost );
+    Impl( const QString& qmlFile, const std::string& streamHost,
+          const std::string& streamName );
 
     ~Impl();
 
@@ -96,6 +97,7 @@ private slots:
     void _onWheeled( double, double, double );
 
 private:
+    std::string _getDeflectStreamName() const;
     bool _setupDeflectStream();
     void _updateSizes( const QSize& size );
 
@@ -113,6 +115,7 @@ private:
     EventReceiver* _eventHandler;
     bool _streaming;
     const std::string _streamHost;
+    const std::string _streamName;
     SizeHints _sizeHints;
 };
 

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#Changelog}
 
 ## Deflect 0.9 (git master)
 
+* [65](https://github.com/BlueBrain/Deflect/pull/65):
+  QmlStreamer: New 'streamname' command line option.
 * [64](https://github.com/BlueBrain/Deflect/pull/64):
   QmlStreamer: Fix event forwarding, implement wheel event support  
 * [60](https://github.com/BlueBrain/Deflect/pull/60): 


### PR DESCRIPTION
Needed by DisplayCluster to programatically enforce the (potentially unknown)
name of the AppLauncher Qml streamer.
