### PR TITLE
Add access to QmlEngine from QmlStreamer

### DIFF
--- a/deflect/qt/QmlStreamer.cpp
+++ b/deflect/qt/QmlStreamer.cpp
@@ -61,5 +61,11 @@ QQuickItem* QmlStreamer::getRootItem()
     return _impl->getRootItem();
 }
 
+QQmlEngine* QmlStreamer::getQmlEngine()
+{
+    return _impl->getQmlEngine();
+}
+
+
 }
 }

--- a/deflect/qt/QmlStreamer.h
+++ b/deflect/qt/QmlStreamer.h
@@ -44,6 +44,7 @@
 
 #include <QString>
 #include <QQuickItem>
+#include <QQmlEngine>
 
 #include <memory>
 #include <string>
@@ -80,6 +81,9 @@ public:
 
     /** @return the QML root item, might be nullptr if not ready yet. */
     DEFLECTQT_API QQuickItem* getRootItem();
+
+    /** @return the QML engine. */
+    DEFLECTQT_API QQmlEngine* getQmlEngine();
 
 private:
     QmlStreamer( const QmlStreamer& ) = delete;

--- a/deflect/qt/QmlStreamerImpl.h
+++ b/deflect/qt/QmlStreamerImpl.h
@@ -76,6 +76,7 @@ public:
     ~Impl();
 
     QQuickItem* getRootItem() { return _rootItem; }
+    QQmlEngine* getQmlEngine() { return _qmlEngine; }
 
 protected:
     void resizeEvent( QResizeEvent* e ) final;


### PR DESCRIPTION
Qt ImageProvider class needs access to engine for providing images. ( Will soon be needed by Folder View in DisplayCluster )
