### PR TITLE
Fix Lambda shadow error with variable size

### DIFF
--- a/deflect/qt/QmlStreamerImpl.cpp
+++ b/deflect/qt/QmlStreamerImpl.cpp
@@ -309,17 +309,17 @@ bool QmlStreamer::Impl::_setupRootItem()
                                              _rootItem->height( ))); } );
 
     connect( _quickWindow, &QQuickWindow::minimumWidthChanged,
-             [this]( int size ) { _sizeHints.minWidth = size; } );
+             [this]( int lambdaSize ) { _sizeHints.minWidth = lambdaSize; } );
     connect( _quickWindow, &QQuickWindow::minimumHeightChanged,
-             [this]( int size ) { _sizeHints.minHeight = size; } );
+             [this]( int lambdaSize ) { _sizeHints.minHeight = lambdaSize; } );
     connect( _quickWindow, &QQuickWindow::maximumWidthChanged,
-             [this]( int size ) { _sizeHints.maxWidth = size; } );
+             [this]( int lambdaSize ) { _sizeHints.maxWidth = lambdaSize; } );
     connect( _quickWindow, &QQuickWindow::maximumHeightChanged,
-             [this]( int size ) { _sizeHints.maxHeight = size; } );
+             [this]( int lambdaSize ) { _sizeHints.maxHeight = lambdaSize; } );
     connect( _quickWindow, &QQuickWindow::widthChanged,
-             [this]( int size ) { _sizeHints.preferredWidth = size; } );
+             [this]( int lambdaSize ) { _sizeHints.preferredWidth = lambdaSize; } );
     connect( _quickWindow, &QQuickWindow::heightChanged,
-             [this]( int size ) { _sizeHints.preferredHeight = size; } );
+             [this]( int lambdaSize ) { _sizeHints.preferredHeight = lambdaSize; } );
 
     // The root item is ready. Associate it with the window.
     _rootItem->setParentItem( _quickWindow->contentItem( ));

--- a/deflect/qt/QmlStreamerImpl.cpp
+++ b/deflect/qt/QmlStreamerImpl.cpp
@@ -309,17 +309,17 @@ bool QmlStreamer::Impl::_setupRootItem()
                                              _rootItem->height( ))); } );
 
     connect( _quickWindow, &QQuickWindow::minimumWidthChanged,
-             [this]( int lambdaSize ) { _sizeHints.minWidth = lambdaSize; } );
+             [this]( int size_ ) { _sizeHints.minWidth = size_; } );
     connect( _quickWindow, &QQuickWindow::minimumHeightChanged,
-             [this]( int lambdaSize ) { _sizeHints.minHeight = lambdaSize; } );
+             [this]( int size_ ) { _sizeHints.minHeight = size_; } );
     connect( _quickWindow, &QQuickWindow::maximumWidthChanged,
-             [this]( int lambdaSize ) { _sizeHints.maxWidth = lambdaSize; } );
+             [this]( int size_ ) { _sizeHints.maxWidth = size_; } );
     connect( _quickWindow, &QQuickWindow::maximumHeightChanged,
-             [this]( int lambdaSize ) { _sizeHints.maxHeight = lambdaSize; } );
+             [this]( int size_ ) { _sizeHints.maxHeight = size_; } );
     connect( _quickWindow, &QQuickWindow::widthChanged,
-             [this]( int lambdaSize ) { _sizeHints.preferredWidth = lambdaSize; } );
+             [this]( int size_ ) { _sizeHints.preferredWidth = size_; } );
     connect( _quickWindow, &QQuickWindow::heightChanged,
-             [this]( int lambdaSize ) { _sizeHints.preferredHeight = lambdaSize; } );
+             [this]( int size_ ) { _sizeHints.preferredHeight = size_; } );
 
     // The root item is ready. Associate it with the window.
     _rootItem->setParentItem( _quickWindow->contentItem( ));


### PR DESCRIPTION
Hi

When I try to build this with v1.10 of Equalizer, i get an error (not warning) about the variable 'size' in the following lambda expressions being shadowed. While not entirely understanding the reason for the lambda, i think i see the intent (which is to pass in an int, and assign it to a member variable) and so the rename seems right. Sorry if it's a bad choice. :)

This is on gentoo linux, during Equalizer Build:

```
[ 47%] Building CXX object Deflect/deflect/qt/CMakeFiles/DeflectQt.dir/QmlStreamerImpl.cpp.o
cd /touro/dev/equalizer/v1.10/build/Deflect/deflect/qt && /usr/bin/c++   -DBOOST_ALL_NO_LIB -DBoost_NO_BOOST_CMAKE -DCOMMON_LITTLEENDIAN -DCOMMON_USE_CXX11=1 -DCXX_ARRAY_SUPPORTED -DCXX_AUTO_SUPPORTED -DCXX_FINAL_OVERRIDE_SUPPORTED -DCXX_NOEXCEPT_SUPPORTED -DCXX_NULLPTR_SUPPORTED -DCXX_SHAREDPTR_SUPPORTED -DCXX_TEMPLATE_ALIAS_SUPPORTED -DCXX_TUPLE_SUPPORTED -DCXX_UNORDERED_MAP_SUPPORTED -DDEFLECTQT_DSO_NAME=\"libDeflectQt.so.2\" -DDEFLECTQT_SHARED -DDEFLECT_USE_BOOST=1 -DDEFLECT_USE_GLUT=1 -DDEFLECT_USE_LIBJPEGTURBO=1 -DDEFLECT_USE_OPENGL=1 -DDEFLECT_USE_QT5CONCURRENT=1 -DDEFLECT_USE_QT5CORE=1 -DDEFLECT_USE_QT5NETWORK=1 -DDEFLECT_USE_QT5QML=1 -DDEFLECT_USE_QT5QUICK=1 -DDEFLECT_USE_QT5WIDGETS=1 -DDEFLECT_USE_SERVUS=1 -DDEFLECT_VERSION=0.9.1 -DDeflectQt_EXPORTS -DEQUALIZER_VERSION=1.11.0 -DLinux=1 -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_QML_LIB -DQT_QUICK_LIB -DWARN_DEPRECATED -Wall -Wextra -Winvalid-pch -Winit-self -Wno-unknown-pragmas -Werror -Wshadow -fmax-errors=5 -Wnon-virtual-dtor -Wsign-promo -Wvla -fno-strict-aliasing -Wall -Wextra -Winvalid-pch -Winit-self -Wno-unknown-pragmas -Werror -Wshadow -fmax-errors=5 -Wnon-virtual-dtor -Wsign-promo -Wvla -fno-strict-aliasing  -std=c++11   -g -fPIC -isystem /usr/lib64/qt5/mkspecs/linux-g++ -isystem /usr/include/qt5/QtCore -isystem /usr/include/qt5/QtConcurrent -isystem /usr/include/qt5 -I/touro/dev/equalizer/v1.10/build/Deflect/include -I/touro/dev/equalizer/v1.10/Deflect -I/touro/dev/equalizer/v1.10/build/include -I/touro/dev/equalizer/v1.10 -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/qt5/QtQml -isystem /usr/include/qt5/QtQuick -isystem /usr/include/qt5/QtGui -I/usr/include/qt5/QtWidgets -I/touro/dev/equalizer/v1.10/build/Deflect    -fPIC -fPIC -fPIC -o CMakeFiles/DeflectQt.dir/QmlStreamerImpl.cpp.o -c /touro/dev/equalizer/v1.10/Deflect/deflect/qt/QmlStreamerImpl.cpp
/touro/dev/equalizer/v1.10/Deflect/deflect/qt/QmlStreamerImpl.cpp: In lambda function:
/touro/dev/equalizer/v1.10/Deflect/deflect/qt/QmlStreamerImpl.cpp:312:31: error: declaration of 'size' shadows a member of 'this' [-Werror=shadow]
              [this]( int size ) { _sizeHints.minWidth = size; } );
```
