### PR TITLE
Fix incomplete socket send under certain timing conditions

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -6,6 +6,8 @@ Changelog {#Changelog}
 ### 0.11.0 (git master)
 * [100](https://github.com/BlueBrain/Deflect/pull/100):
   QmlStreamer: correcly quit application when stream is closed.
+* [99](https://github.com/BlueBrain/Deflect/pull/99):
+  Fix incomplete socket send under certain timing conditions
 * [95](https://github.com/BlueBrain/Deflect/pull/95):
   DesktopStreamer: the list of windows available for streaming is also updated
   after a window has been hidden or unhidden.


### PR DESCRIPTION
Observed with Stream::asyncSend() and offscreen Equalizer-based application
streaming: the last frame before the applications is idling is not received
by the server, due to missing flush of the send buffer.
