### PR TITLE
DesktopStreamer: windows that are streamed independently are activated

### DIFF
--- a/apps/DesktopStreamer/DesktopWindowsModel.h
+++ b/apps/DesktopStreamer/DesktopWindowsModel.h
@@ -43,7 +43,8 @@ public:
     enum DataRole
     {
         ROLE_PIXMAP = Qt::UserRole,
-        ROLE_RECT
+        ROLE_RECT,
+        ROLE_PID
     };
 
     /** @internal */
@@ -51,6 +52,24 @@ public:
 
     /** @internal */
     void removeApplication( void* app );
+
+    /**
+     * Check if the application corresponding to the specified PID is currently
+     * active
+     *
+     * @param pid the application process id
+     * @return true if the application with the PID specified is currently
+     *         active
+     */
+    static bool isActive( int pid );
+
+    /**
+     * Activate the application corresponding to the specified PID. This will
+     * send the application to the front
+     *
+     * @param pid the application process id
+     */
+    static void activate( int pid );
 
 private:
     class Impl;

--- a/apps/DesktopStreamer/MainWindow.cpp
+++ b/apps/DesktopStreamer/MainWindow.cpp
@@ -201,7 +201,10 @@ void MainWindow::_updateStreams()
         const std::string streamId = std::to_string( ++_streamID ) +
                                        " " + appName + " - " +
                                       _streamIdLineEdit->text().toStdString();
-        StreamPtr stream( new Stream( *this, index, streamId, host ));
+        const int pid = index.isValid() ?
+            _listView->model()->data( index,
+                                      DesktopWindowsModel::ROLE_PID).toInt(): 0;
+        StreamPtr stream( new Stream( *this, index, streamId, host, pid ));
 
         if( !stream->isConnected( ))
         {

--- a/apps/DesktopStreamer/Stream.h
+++ b/apps/DesktopStreamer/Stream.h
@@ -52,7 +52,7 @@ class Stream : public deflect::Stream
 public:
     /** Construct a new stream for the given desktop window. */
     Stream( const MainWindow& parent, const QPersistentModelIndex window,
-            const std::string& id, const std::string& host );
+            const std::string& id, const std::string& host, const int pid = 0 );
     ~Stream();
 
     /**
@@ -69,22 +69,14 @@ public:
      */
     bool processEvents( bool interact );
 
-    const QPersistentModelIndex& getIndex() const { return _window; }
+    const QPersistentModelIndex& getIndex() const;
 
 private:
-    const MainWindow& _parent;
-    const QPersistentModelIndex _window;
-    QRect _windowRect; // position on host in non-retina coordinates
-    const QImage _cursor;
-    QImage _image;
-
     Stream( const Stream& ) = delete;
     Stream( Stream&& ) = delete;
 
-    void _sendMousePressEvent( float x, float y );
-    void _sendMouseMoveEvent( float x, float y );
-    void _sendMouseReleaseEvent( float x, float y );
-    void _sendMouseDoubleClickEvent( float x, float y );
+    class Impl;
+    std::unique_ptr< Impl > _impl;
 };
 
 #endif

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -8,13 +8,17 @@ Changelog {#Changelog}
 * [102](https://github.com/BlueBrain/Deflect/pull/102):
   DeflectQt: Continue rendering & streaming after updates for a while to
   compensate for running animations, fix spurious missing event handling  
+* [101](https://github.com/BlueBrain/Deflect/pull/101):
+  DesktopStreamer: windows that are streamed independently are activated
+  (i.e. sent to the foreground) before applying an interaction event. The mouse
+  cursor is now rendered only on active windows or desktop.
 * [100](https://github.com/BlueBrain/Deflect/pull/100):
   QmlStreamer: correcly quit application when stream is closed.
 * [99](https://github.com/BlueBrain/Deflect/pull/99):
   Fix incomplete socket send under certain timing conditions
 * [98](https://github.com/BlueBrain/Deflect/pull/98):
   Streams can be constructed based on the DEFLECT_ID and DEFLECT_HOST ENV_VARs.
-* [95](https://github.com/BlueBrain/Deflect/pull/95):
+* [97](https://github.com/BlueBrain/Deflect/pull/97):
   DesktopStreamer: the list of windows available for streaming is also updated
   after a window has been hidden or unhidden.
 * [94](https://github.com/BlueBrain/Deflect/pull/94):


### PR DESCRIPTION
(i.e. sent to the foreground) before applying an interaction event.

The mouse cursor is now rendered only on active windows or desktop.
Fix crash when hiding (cmd+H) the DesktopStreamer app.
