### PR TITLE
DesktopStreamer: prevent AppNap of being re-enabled automatically

### DIFF
--- a/apps/DesktopStreamer/MainWindow.cpp
+++ b/apps/DesktopStreamer/MainWindow.cpp
@@ -166,6 +166,13 @@ void MainWindow::closeEvent( QCloseEvent* closeEvt )
 
 void MainWindow::_update()
 {
+#ifdef __APPLE__
+    // On OS X >= 10.9 AppNap switches on/off automatically based on the app
+    // visibility. We can avoid this by actively checking the state of the
+    // AppNapSuspender (calling 'suspend' does the check, it will rarely need to
+    // disable the AppNap feature if it was already disabled)
+    _napSuspender.suspend();
+#endif
     _frameTime.start();
     if( _streamButton->isChecked( ))
     {

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -5,6 +5,8 @@ Changelog {#Changelog}
 
 ### 0.11.0 (git master)
 
+* [103](https://github.com/BlueBrain/Deflect/pull/103):
+  DesktopStreamer: prevent AppNap of being re-enabled automatically
 * [102](https://github.com/BlueBrain/Deflect/pull/102):
   DeflectQt: Continue rendering & streaming after updates for a while to
   compensate for running animations, fix spurious missing event handling  


### PR DESCRIPTION
Otherwise, it switches back on after some time
(e.g. when the window is occluded)
