### PR TITLE
Attempt to fix problematic unit test

### DIFF
--- a/tests/cpp/ServerTests.cpp
+++ b/tests/cpp/ServerTests.cpp
@@ -140,6 +140,7 @@ BOOST_AUTO_TEST_CASE( testRegisterForEventReceivedByServer )
         streamId = id;
         exclusiveBind = exclusive;
         eventReceiver = receiver;
+        server->onEventRegistrationReply( id, true ); // send reply to Stream
         mutex.lock();
         receivedState = true;
         received.wakeAll();
@@ -150,8 +151,7 @@ BOOST_AUTO_TEST_CASE( testRegisterForEventReceivedByServer )
         deflect::Stream stream( testStreamId.toStdString(), "localhost",
                                 server->serverPort( ));
         BOOST_REQUIRE( stream.isConnected( ));
-        // Just send an event to check the streamId received by the server
-        stream.registerForEvents( true );
+        BOOST_CHECK( stream.registerForEvents( true ));
     }
 
     for( size_t i = 0; i < 20; ++i )


### PR DESCRIPTION
deflect::Stream::registerForEvents: receive bind reply failed
../Deflect/tests/cpp/ServerTests.cpp(230): error in
"testDataReceivedByServer": check !"reachable" failed
QThread: Destroyed while thread is still running
