### PR TITLE
QmlStreamer: bugfix and improvement for WebEngineView

### DIFF
--- a/deflect/qt/QmlStreamer.h
+++ b/deflect/qt/QmlStreamer.h
@@ -65,8 +65,12 @@ namespace qt
  *
  * When using a WebEngineView, users must call QtWebEngine::initialize() in the
  * QApplication before creating the streamer. Also, due to a limitiation in Qt,
- * the objectName property of any WebEngineView must be set to "webengineview"
- * for it to receive keyboard events.
+ * the objectName property of any WebEngineView must be set to "webengineview".
+ * This is necessary for it to receive keyboard events and to correct the
+ * default behaviour of the tapAndHold gesture. Deflect will prevent the opening
+ * of an on-screen context menu (which may crash the application) and instead
+ * switch to a "mouse" interaction mode. This allows users to interact within
+ * a WebGL canevas or select text instead of scrolling the page.
  */
 class QmlStreamer : public QObject
 {

--- a/deflect/qt/QmlStreamerImpl.h
+++ b/deflect/qt/QmlStreamerImpl.h
@@ -113,6 +113,11 @@ private:
     void _updateSizes( const QSize& size );
     QTouchEvent::TouchPoint _makeTouchPoint( int id, const QPointF& pos ) const;
 
+    void _startMouseModeSwitchDetection( const QPointF& pos );
+    bool _touchIsTapAndHold();
+    void _switchFromTouchToMouseMode();
+    void _sendMouseEvent( QEvent::Type eventType, const QPointF& pos );
+
     QOpenGLContext* _context;
     QOffscreenSurface* _offscreenSurface;
     QQuickRenderControl* _renderControl;
@@ -134,6 +139,11 @@ private:
     SizeHints _sizeHints;
 
     QTouchDevice _device;
+
+    QTimer _mouseModeTimer;
+    bool _mouseMode;
+    QPointF _touchStartPos;
+    QPointF _touchCurrentPos;
 };
 
 }

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -5,6 +5,10 @@ Changelog {#Changelog}
 
 ### 0.12.0 (git master)
 
+* [124](https://github.com/BlueBrain/Deflect/pull/124):
+  QmlStreamer: Users can now interact with WebGL content in a WebEngineView
+  and no longer risk opening a system context menu with a long press (prevent
+  crashes in certain offscreen applications).
 * [123](https://github.com/BlueBrain/Deflect/pull/123):
   QmlStreamer is now compatible with Qml WebEngineView items. Users must call
   QtWebEngine::initialize() in their QApplication before creating the stream.


### PR DESCRIPTION
- prevent WebEngineView from opening a content menu on tapAndHold
- switch to mouse interaction on TapAndHold to allow interaction with
  WebGl contents instead of scrolling the page.
