### PR TITLE
DesktopStreamer: use full user name as default stream name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@ notifications:
     on_success: never
 language: cpp
 sudo: false
-cache:
-  ccache: true
-  pip: true
-  directories:
-  - /usr/local
-before_cache:
-  - brew cleanup
 os:
   - osx
 env:
@@ -31,4 +24,3 @@ script:
   - cd $BUILD_TYPE
   - cmake -GNinja -DCMAKE_INSTALL_PREFIX=$PWD/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
   - ninja all && ninja $PROJECT_NAME-tests && ninja install
-

--- a/apps/DesktopStreamer/CMakeLists.txt
+++ b/apps/DesktopStreamer/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-# Copyright (c) 2013-2015, EPFL/Blue Brain Project
-#                     Raphael Dumusc <raphael.dumusc@epfl.ch>
+# Copyright (c) 2013-2016, EPFL/Blue Brain Project
+#                          Raphael Dumusc <raphael.dumusc@epfl.ch>
 
 set(DESKTOPSTREAMER_HEADERS
   MainWindow.h

--- a/apps/DesktopStreamer/CMakeLists.txt
+++ b/apps/DesktopStreamer/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 set(DESKTOPSTREAMER_HEADERS
   MainWindow.h
+  nameUtils.h
   Stream.h
 )
 
@@ -21,6 +22,12 @@ set(DESKTOPSTREAMER_LINK_LIBRARIES
   Qt5::Network
   Qt5::Widgets
 )
+
+if(APPLE)
+  list(APPEND DESKTOPSTREAMER_SOURCES nameUtils.mm)
+else()
+  list(APPEND DESKTOPSTREAMER_SOURCES nameUtils.cpp)
+endif()
 
 set(DEFLECT_DESKTOPSTREAMER_HOSTS
     "\

--- a/apps/DesktopStreamer/MainWindow.cpp
+++ b/apps/DesktopStreamer/MainWindow.cpp
@@ -96,10 +96,10 @@ MainWindow::MainWindow()
              });
 
     const auto username = nameutils::getFullUsername();
-    if( !username.isEmpty( ))
-        _streamIdLineEdit->setText( username + "'s Desktop" );
-    else
+    if( username.isEmpty( ))
         _streamIdLineEdit->setText( QHostInfo::localHostName( ));
+    else
+        _streamIdLineEdit->setText( username + "'s Desktop" );
 
     connect( _streamButton, &QPushButton::clicked,
              this, &MainWindow::_update );

--- a/apps/DesktopStreamer/MainWindow.cpp
+++ b/apps/DesktopStreamer/MainWindow.cpp
@@ -39,6 +39,7 @@
 /*********************************************************************/
 
 #include "MainWindow.h"
+#include "nameUtils.h"
 #include "Stream.h"
 
 #include <deflect/version.h>
@@ -94,7 +95,11 @@ MainWindow::MainWindow()
                 _listView->setEnabled( !text.isEmpty( ));
              });
 
-    _streamIdLineEdit->setText( QHostInfo::localHostName( ));
+    const auto username = nameutils::getFullUsername();
+    if( !username.isEmpty( ))
+        _streamIdLineEdit->setText( username + "'s Desktop" );
+    else
+        _streamIdLineEdit->setText( QHostInfo::localHostName( ));
 
     connect( _streamButton, &QPushButton::clicked,
              this, &MainWindow::_update );

--- a/apps/DesktopStreamer/nameUtils.cpp
+++ b/apps/DesktopStreamer/nameUtils.cpp
@@ -1,0 +1,48 @@
+/* Copyright (c) 2016, EPFL/Blue Brain Project
+ *                     Raphael Dumusc <raphael.dumusc@epfl.ch>
+ *
+ * This file is part of Deflect <https://github.com/BlueBrain/Deflect>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "nameUtils.h"
+
+#ifndef _WIN32
+#include <pwd.h>
+#endif
+
+namespace nameutils
+{
+
+QString getFullUsername()
+{
+#ifdef _WIN32
+    return qgetenv( "USERNAME" );
+#else
+    const auto username = qgetenv( "USER" );
+    if( username.isEmpty( ))
+        return {};
+
+    if( auto userinfo = getpwnam( username.constData( )))
+    {
+        const auto fullname = QString{ userinfo->pw_gecos };
+        if( !fullname.isEmpty( ))
+            return fullname;
+    }
+    return username;
+#endif
+}
+
+}

--- a/apps/DesktopStreamer/nameUtils.cpp
+++ b/apps/DesktopStreamer/nameUtils.cpp
@@ -20,7 +20,7 @@
 #include "nameUtils.h"
 
 #ifndef _WIN32
-#include <pwd.h>
+#  include <pwd.h>
 #endif
 
 namespace nameutils
@@ -31,7 +31,9 @@ QString getFullUsername()
 #ifdef _WIN32
     return qgetenv( "USERNAME" );
 #else
-    const auto username = qgetenv( "USER" );
+    auto username = qgetenv( "USER" );
+    if( username.isEmpty( ))
+        username = qgetenv( "USERNAME" );
     if( username.isEmpty( ))
         return {};
 

--- a/apps/DesktopStreamer/nameUtils.h
+++ b/apps/DesktopStreamer/nameUtils.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2016, EPFL/Blue Brain Project
+ *                     Raphael Dumusc <raphael.dumusc@epfl.ch>
+ *
+ * This file is part of Deflect <https://github.com/BlueBrain/Deflect>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef NAMEUTILS_H
+#define NAMEUTILS_H
+
+#include <QString>
+
+/**
+ * Cross-plateform utilities to retrieve the name of the user.
+ */
+namespace nameutils
+{
+
+/**
+ * Retrieve the full name of the user (e.g. "John Doe").
+ * @return full name if available, else the basic username or an empty string.
+ */
+QString getFullUsername();
+
+}
+
+#endif

--- a/apps/DesktopStreamer/nameUtils.h
+++ b/apps/DesktopStreamer/nameUtils.h
@@ -17,13 +17,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NAMEUTILS_H
-#define NAMEUTILS_H
+#pragma once
 
 #include <QString>
 
 /**
- * Cross-plateform utilities to retrieve the name of the user.
+ * Cross-platform utilities to retrieve the name of the user.
  */
 namespace nameutils
 {
@@ -35,5 +34,3 @@ namespace nameutils
 QString getFullUsername();
 
 }
-
-#endif

--- a/apps/DesktopStreamer/nameUtils.mm
+++ b/apps/DesktopStreamer/nameUtils.mm
@@ -1,0 +1,36 @@
+/* Copyright (c) 2016, EPFL/Blue Brain Project
+ *                     Raphael Dumusc <raphael.dumusc@epfl.ch>
+ *
+ * This file is part of Deflect <https://github.com/BlueBrain/Deflect>
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3.0 as published
+ * by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "nameUtils.h"
+
+#import <Foundation/NSPathUtilities.h>
+
+namespace nameutils
+{
+
+QString getFullUsername()
+{
+    const auto fullname = QString{ [NSFullUserName() UTF8String] };
+    if( !fullname.isEmpty( ))
+        return fullname;
+
+    return qgetenv( "USER" );
+}
+
+}

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -5,6 +5,8 @@ Changelog {#Changelog}
 
 ### 0.12.0 (git master)
 
+* [141](https://github.com/BlueBrain/Deflect/pull/141):
+  The DesktopStreamer app uses the full user name as the default stream name.
 * [139](https://github.com/BlueBrain/Deflect/pull/139):
   OSX: AppNap is now disabled for all QmlStreamers. The AppNapSuspender class
   is now available in Deflect library for use in external applications.

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -5,7 +5,7 @@ Changelog {#Changelog}
 
 ### 0.12.0 (git master)
 
-* [141](https://github.com/BlueBrain/Deflect/pull/141):
+* [140](https://github.com/BlueBrain/Deflect/pull/140):
   The DesktopStreamer app uses the full user name as the default stream name.
 * [139](https://github.com/BlueBrain/Deflect/pull/139):
   OSX: AppNap is now disabled for all QmlStreamers. The AppNapSuspender class


### PR DESCRIPTION
Just seeing 'tsf-476-wpa-1-249.epfl.ch' right now on the wall. ;)

Ideally I would want the full user name, e.g., 'Stefan Eilemann' and not
'eilemann' as this change does, but getting this information seems way
harder.