### PR TITLE
Remove dependency on Qt5::Gui private headers for setting global GL shared context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(DEFLECT_LICENSE BSD)
 set(DEFLECT_DEB_DEPENDS freeglut3-dev libxi-dev libxmu-dev
   libjpeg-turbo8-dev libturbojpeg
   libboost-program-options-dev libboost-test-dev
-  qtbase5-dev qtbase5-private-dev qtdeclarative5-dev)
+  qtbase5-dev qtdeclarative5-dev)
 set(DEFLECT_PORT_DEPENDS boost freeglut qt5)
 
 include(Common)
@@ -28,7 +28,6 @@ common_find_package(LibJpegTurbo REQUIRED)
 common_find_package(OpenGL)
 common_find_package(Qt5Concurrent REQUIRED SYSTEM)
 common_find_package(Qt5Core REQUIRED)
-common_find_package(Qt5Gui COMPONENTS Private) # For Qml WebEngineView
 if(APPLE)
   common_find_package(Qt5MacExtras)
 endif()

--- a/deflect/qt/CMakeLists.txt
+++ b/deflect/qt/CMakeLists.txt
@@ -33,8 +33,3 @@ common_library(DeflectQt)
 if(DEFLECT_QMLSTREAMER_MULTITHREADED)
   target_compile_definitions(DeflectQt PRIVATE DEFLECTQT_MULTITHREADED)
 endif()
-
-if(TARGET Qt5::Gui)
-  target_include_directories(DeflectQt SYSTEM PRIVATE
-    "$<BUILD_INTERFACE:${Qt5Gui_PRIVATE_INCLUDE_DIRS}>")
-endif()

--- a/deflect/qt/QuickRenderer.cpp
+++ b/deflect/qt/QuickRenderer.cpp
@@ -1,6 +1,7 @@
 /*********************************************************************/
-/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2016-2017, EPFL/Blue Brain Project                  */
+/*                          Daniel.Nachbaur@epfl.ch                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -47,9 +48,12 @@
 #include <QQuickRenderControl>
 #include <QQuickWindow>
 
-#ifdef DEFLECT_USE_QT5GUI
-#  include <QtGui/private/qopenglcontext_p.h>
-#endif
+// Forward-declare the function defined in <QtGui/private/qopenglcontext_p.h> to
+// remove the need for private headers. This internal API should remain stable
+// because it is also used by QtWebengine for the same reason.
+QT_BEGIN_NAMESPACE
+Q_GUI_EXPORT void qt_gl_set_global_share_context( QOpenGLContext* context );
+QT_END_NAMESPACE
 
 namespace deflect
 {
@@ -190,11 +194,7 @@ void QuickRenderer::_createGLContext()
     // Test if user has setup shared GL contexts (QtWebEngine::initialize).
     // If so, setup global share context needed by the Qml WebEngineView.
     if( QCoreApplication::testAttribute( Qt::AA_ShareOpenGLContexts ))
-#if DEFLECT_USE_QT5GUI
         qt_gl_set_global_share_context( _context.get( ));
-#else
-        qWarning() << "DeflectQt was not compiled with WebEngineView support";
-#endif
 }
 
 void QuickRenderer::_initRenderControl()
@@ -220,9 +220,7 @@ void QuickRenderer::_onStop()
 
     _offscreenSurface.reset();
 
-#if DEFLECT_USE_QT5GUI
     qt_gl_set_global_share_context( nullptr );
-#endif
     _context.reset();
 }
 


### PR DESCRIPTION
Follow up of discussion:
https://github.com/Eyescale/Equalizer/pull/619#issuecomment-281073544