### PR TITLE
Server: improved even registration mechanism

### DIFF
--- a/deflect/MetaTypeRegistration.cpp
+++ b/deflect/MetaTypeRegistration.cpp
@@ -1,5 +1,5 @@
 /*********************************************************************/
-/* Copyright (c) 2014-2015, EPFL/Blue Brain Project                  */
+/* Copyright (c) 2014-2017, EPFL/Blue Brain Project                  */
 /*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
@@ -41,6 +41,7 @@
 #include "Event.h"
 #include "Segment.h"
 #include "SizeHints.h"
+#include "types.h"
 
 #include <QMetaType>
 
@@ -54,6 +55,7 @@ struct MetaTypeRegistration
     MetaTypeRegistration()
     {
         qRegisterMetaType<size_t>("size_t");
+        qRegisterMetaType<deflect::BoolPromisePtr>("deflect::BoolPromisePtr");
         qRegisterMetaType<deflect::Segment>("deflect::Segment");
         qRegisterMetaType<deflect::SizeHints>("deflect::SizeHints");
         qRegisterMetaType<deflect::Event>("deflect::Event");

--- a/deflect/Server.cpp
+++ b/deflect/Server.cpp
@@ -1,5 +1,5 @@
 /*********************************************************************/
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
+/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
 /*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
@@ -100,11 +100,6 @@ void Server::closePixelStream(const QString uri)
     _impl->frameDispatcher.deleteStream(uri);
 }
 
-void Server::replyToEventRegistration(const QString uri, const bool success)
-{
-    emit _eventRegistrationReply(uri, success);
-}
-
 void Server::incomingConnection(const qintptr socketHandle)
 {
     QThread* workerThread = new QThread(this);
@@ -131,8 +126,6 @@ void Server::incomingConnection(const qintptr socketHandle)
     connect(worker, &ServerWorker::receivedData, this, &Server::receivedData);
     connect(this, &Server::_closePixelStream, worker,
             &ServerWorker::closeConnection);
-    connect(this, &Server::_eventRegistrationReply, worker,
-            &ServerWorker::replyToEventRegistration);
 
     // FrameDispatcher
     connect(worker, &ServerWorker::addStreamSource, &_impl->frameDispatcher,

--- a/deflect/Server.h
+++ b/deflect/Server.h
@@ -91,14 +91,6 @@ public slots:
     void requestFrame(QString uri);
 
     /**
-     * Reply to an event registration request after a registerToEvents() signal.
-     *
-     * @param uri Identifier for the stream
-     * @param success Result of the registration operation
-     */
-    void replyToEventRegistration(QString uri, bool success);
-
-    /**
      * Close a pixel stream, disconnecting the remote client.
      *
      * @param uri Identifier for the stream
@@ -136,9 +128,11 @@ signals:
      * @param uri Identifier for the stream
      * @param exclusive true if the receiver should receive events exclusively
      * @param receiver the event receiver instance
+     * @param success the promise that must receive the success of the operation
      */
     void registerToEvents(QString uri, bool exclusive,
-                          deflect::EventReceiver* receiver);
+                          deflect::EventReceiver* receiver,
+                          deflect::BoolPromisePtr success);
 
     /**
      * Emitted when a remote client sends size hints for displaying the stream.
@@ -165,7 +159,6 @@ private:
 
 signals:
     void _closePixelStream(QString uri);
-    void _eventRegistrationReply(QString uri, bool success);
 };
 }
 

--- a/deflect/ServerWorker.h
+++ b/deflect/ServerWorker.h
@@ -1,5 +1,5 @@
 /*********************************************************************/
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
+/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
 /*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
@@ -46,6 +46,7 @@
 #include <deflect/MessageHeader.h>
 #include <deflect/Segment.h>
 #include <deflect/SizeHints.h>
+#include <deflect/types.h>
 
 #include <QQueue>
 #include <QtNetwork/QTcpSocket>
@@ -65,7 +66,6 @@ public slots:
 
     void initConnection();
     void closeConnection(QString uri);
-    void replyToEventRegistration(QString uri, bool success);
 
 signals:
     void addStreamSource(QString uri, size_t sourceIndex);
@@ -76,7 +76,8 @@ signals:
     void receivedFrameFinished(QString uri, size_t sourceIndex);
 
     void registerToEvents(QString uri, bool exclusive,
-                          deflect::EventReceiver* receiver);
+                          deflect::EventReceiver* receiver,
+                          deflect::BoolPromisePtr success);
 
     void receivedSizeHints(QString uri, deflect::SizeHints hints);
 

--- a/deflect/types.h
+++ b/deflect/types.h
@@ -43,6 +43,7 @@
 
 #include <deflect/config.h>
 
+#include <future>
 #include <memory>
 #include <vector>
 
@@ -85,9 +86,10 @@ struct Segment;
 struct SegmentParameters;
 struct SizeHints;
 
-typedef std::shared_ptr<Frame> FramePtr;
-typedef std::vector<Segment> Segments;
-typedef std::vector<SegmentParameters> SegmentParametersList;
+using BoolPromisePtr = std::shared_ptr<std::promise<bool>>;
+using FramePtr = std::shared_ptr<Frame>;
+using Segments = std::vector<Segment>;
+using SegmentParametersList = std::vector<SegmentParameters>;
 
 namespace qt
 {

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#Changelog}
 
 ## Deflect 0.13 (git master)
 
+* [157](https://github.com/BlueBrain/Deflect/pull/157):
+  Better event registration mechanism, fixes warnings in the multi-client case.
 * [154](https://github.com/BlueBrain/Deflect/pull/154):
   On the server side, segments can be decoded to YUV images, saving CPU time by
   skipping the YUV -> RGB conversion step.

--- a/tests/cpp/ServerTests.cpp
+++ b/tests/cpp/ServerTests.cpp
@@ -136,12 +136,12 @@ BOOST_AUTO_TEST_CASE(testRegisterForEventReceivedByServer)
     bool receivedState = false;
     server->connect(server, &deflect::Server::registerToEvents,
                     [&](const QString id, const bool exclusive,
-                        deflect::EventReceiver* receiver) {
+                        deflect::EventReceiver* receiver,
+                        deflect::BoolPromisePtr success) {
                         streamId = id;
                         exclusiveBind = exclusive;
                         eventReceiver = receiver;
-                        // send reply to Stream
-                        server->replyToEventRegistration(id, true);
+                        success->set_value(true);
                         mutex.lock();
                         receivedState = true;
                         received.wakeAll();


### PR DESCRIPTION
The server now relies on a std::promise to check the success of a request to register for events instead of passively listening for a QSignal to come back. This change brings two improvements:

- It fixes an issue with multiple clients, where all the clients were being notified when any of them tried to register, causing a warning message to be printed.
- The Stream client is notified also if the request is not handled at all by the Server application (broken promise).