### PR TITLE
Stream refactorings: hide QSocketNotifer false warnings

### DIFF
--- a/apps/DesktopStreamer/Stream.cpp
+++ b/apps/DesktopStreamer/Stream.cpp
@@ -78,6 +78,12 @@ public:
         _mouseActiveTimer.setInterval(CURSOR_TIMEOUT_MS);
     }
 
+    ~Impl()
+    {
+        if (_lastSend.valid())
+            _lastSend.get();
+    }
+
     bool processEvents(const bool interact)
     {
         while (_stream.hasEvent())

--- a/deflect/Socket.h
+++ b/deflect/Socket.h
@@ -76,7 +76,7 @@ public:
                        unsigned short port = defaultPortNumber);
 
     /** Destruct a Socket, disconnecting from host. */
-    DEFLECT_API ~Socket();
+    DEFLECT_API ~Socket() = default;
 
     /** Get the host passed to the constructor. */
     const std::string& getHost() const;
@@ -121,13 +121,14 @@ signals:
 
 private:
     const std::string _host;
-    QTcpSocket* _socket;
+    QTcpSocket* _socket; // Child QObject
     mutable QMutex _socketMutex;
     int32_t _serverProtocolVersion;
 
     bool _receiveHeader(MessageHeader& messageHeader);
     bool _connect(const std::string& host, const unsigned short port);
     bool _receiveProtocolVersion();
+    bool _write(const QByteArray& data);
 };
 }
 

--- a/deflect/Stream.h
+++ b/deflect/Stream.h
@@ -1,5 +1,5 @@
 /*********************************************************************/
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
+/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
 /*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /*                          Stefan.Eilemann@epfl.ch                  */
 /*                          Daniel.Nachbaur@epfl.ch                  */
@@ -240,7 +240,7 @@ public:
      * Send size hints to the stream server to indicate sizes that should be
      * respected by resize operations on the server side.
      *
-     * @note do not use while asynchronous send operations are pending.
+     * @note blocks until all pending asynchonous send operations are finished.
      * @param hints the new size hints for the server
      * @version 1.2
      */
@@ -249,7 +249,7 @@ public:
     /**
      * Send data to the Server.
      *
-     * @note do not use while asynchronous send operations are pending.
+     * @note blocks until all pending asynchonous send operations are finished.
      * @param data the pointer to the data buffer.
      * @param count the number of bytes to send.
      * @return true if the data could be sent, false otherwise
@@ -259,11 +259,12 @@ public:
 
     /**
      * Set a function to be be called just after the stream gets disconnected.
+     *
      * @param callback the function to call
      * @note replaces the previous disconnected signal
      * @version 1.5
      */
-    void setDisconnectedCallback(std::function<void()> callback);
+    DEFLECT_API void setDisconnectedCallback(std::function<void()> callback);
 
 private:
     Stream(const Stream&) = delete;

--- a/deflect/StreamPrivate.h
+++ b/deflect/StreamPrivate.h
@@ -1,8 +1,8 @@
 /*********************************************************************/
-/* Copyright (c) 2013-2015, EPFL/Blue Brain Project                  */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
-/*                     Stefan.Eilemann@epfl.ch                       */
-/*                     Daniel.Nachbaur@epfl.ch                       */
+/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
+/*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
+/*                          Stefan.Eilemann@epfl.ch                  */
+/*                          Daniel.Nachbaur@epfl.ch                  */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -42,16 +42,10 @@
 #ifndef DEFLECT_STREAMPRIVATE_H
 #define DEFLECT_STREAMPRIVATE_H
 
-#include <deflect/api.h>
-
-#include "Event.h"
-#include "MessageHeader.h"
 #include "Socket.h"           // member
-#include "Stream.h"           // Stream::Future
 #include "StreamSendWorker.h" // member
 
 #include <functional>
-#include <memory>
 #include <string>
 
 namespace deflect
@@ -73,40 +67,6 @@ public:
     /** Destructor, close the Stream. */
     ~StreamPrivate();
 
-    /** Send the open message to the server. */
-    void sendOpen();
-
-    /** Send the quit message to the server. */
-    void sendClose();
-
-    /**
-     * Close the stream.
-     * @return true on success or if the Stream was not connected
-     */
-    bool close();
-
-    /** @sa Stream::send */
-    Stream::Future send(const ImageWrapper& image);
-
-    /** @sa Stream::sendAndFinish */
-    Stream::Future sendAndFinish(const ImageWrapper& image);
-
-    /** @sa Stream::finishFrame */
-    Stream::Future finishFrame();
-
-    /**
-     * Send a Segment through the Stream.
-     * @param segment An image segment with valid parameters and data
-     * @return true if the message could be sent
-     */
-    DEFLECT_API bool sendPixelStreamSegment(const Segment& segment);
-
-    /** @sa Stream::sendSizeHints */
-    bool sendSizeHints(const SizeHints& hints);
-
-    /** Send a user-defined block of data to the server. */
-    bool send(QByteArray data);
-
     /** The stream identifier. */
     const std::string id;
 
@@ -114,19 +74,13 @@ public:
     Socket socket;
 
     /** Has a successful event registration reply been received */
-    bool registeredForEvents;
+    bool registeredForEvents = false;
 
+    /** Optional callback when the socket is disconnected. */
     std::function<void()> disconnectedCallback;
 
-private:
-    friend class StreamSendWorker;
-
-    /** Send the view for the image to be sent with sendPixelStreamSegment. */
-    bool sendImageView(View view);
-
-    bool sendFinish(); //<! Send the finish frame message
-
-    StreamSendWorker _sendWorker;
+    /** The worker doing all the socket send operations. */
+    StreamSendWorker sendWorker;
 };
 }
 #endif

--- a/deflect/qt/CMakeLists.txt
+++ b/deflect/qt/CMakeLists.txt
@@ -22,8 +22,8 @@ set(DEFLECTQT_SOURCES
   QmlStreamerImpl.cpp
   QuickRenderer.cpp
   TouchInjector.cpp
-
 )
+
 set(DEFLECTQT_LINK_LIBRARIES
   PUBLIC Deflect Qt5::Quick PRIVATE Qt5::Qml)
 set(DEFLECTQT_INCLUDE_NAME deflect/qt)

--- a/tests/cpp/perf/benchmarkStreamer.cpp
+++ b/tests/cpp/perf/benchmarkStreamer.cpp
@@ -260,7 +260,7 @@ public:
         for (deflect::Segments::const_iterator it = _jpegSegments.begin();
              it != _jpegSegments.end(); ++it)
         {
-            if (!_stream->_impl->sendPixelStreamSegment(*it))
+            if (!_stream->_impl->sendWorker._sendSegment(*it))
                 return false;
         }
 


### PR DESCRIPTION
qWarning: "QSocketNotifier: Socket notifiers cannot be enabled or
disabled from another thread"

These warnings were issued by the async Stream API when a QApplication
was present. Using a single QThread for all send operations solves the
problem.

A single warning is still printed during QmlStream registerForEvents(),
this time on socket.receive(), but can be ignored for now.

Also fixed a possible segfault in DesktopStreamer when stopping the
stream.