### PR TITLE
Stereo streaming accepts side-by-side images as input

### DIFF
--- a/deflect/ImageSegmenter.h
+++ b/deflect/ImageSegmenter.h
@@ -1,5 +1,5 @@
 /*********************************************************************/
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
+/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
 /*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /*                          Stefan.Eilemann@epfl.ch                  */
 /* All rights reserved.                                              */
@@ -48,7 +48,6 @@
 #include <deflect/Segment.h>
 
 #include <functional>
-#include <vector>
 
 namespace deflect
 {
@@ -59,7 +58,7 @@ class ImageSegmenter
 {
 public:
     /** Construct an ImageSegmenter. */
-    DEFLECT_API ImageSegmenter();
+    DEFLECT_API ImageSegmenter() = default;
 
     /** Function called on each segment. */
     using Handler = std::function<bool(const Segment&)>;
@@ -90,19 +89,32 @@ public:
      * @param width The nominal width of the segments to generate (default: 0)
      * @param height The nominal height of the segments to generate (default: 0)
      */
-    DEFLECT_API void setNominalSegmentDimensions(unsigned int width,
-                                                 unsigned int height);
+    DEFLECT_API void setNominalSegmentDimensions(uint width, uint height);
 
 private:
-    SegmentParametersList _generateSegmentParameters(
-        const ImageWrapper& image) const;
+    struct SegmentationInfo
+    {
+        uint width = 0;
+        uint height = 0;
+
+        uint countX = 0;
+        uint countY = 0;
+
+        uint lastWidth = 0;
+        uint lastHeight = 0;
+    };
 
     bool _generateJpeg(const ImageWrapper& image, const Handler& handler);
-    bool _generateRaw(const ImageWrapper& image, const Handler& handler) const;
     void _computeJpeg(Segment& task);
+    bool _generateRaw(const ImageWrapper& image, const Handler& handler) const;
 
-    unsigned int _nominalSegmentWidth;
-    unsigned int _nominalSegmentHeight;
+    Segments _generateSegments(const ImageWrapper& image) const;
+    SegmentParametersList _makeSegmentParameters(
+        const ImageWrapper& image) const;
+    SegmentationInfo _makeSegmentationInfo(const ImageWrapper& image) const;
+
+    uint _nominalSegmentWidth = 0;
+    uint _nominalSegmentHeight = 0;
 
     MTQueue<Segment> _sendQueue;
 };

--- a/deflect/StreamSendWorker.cpp
+++ b/deflect/StreamSendWorker.cpp
@@ -83,7 +83,7 @@ void StreamSendWorker::run()
         lock.unlock();
 
         bool success = true;
-        for (auto&& task : request.tasks)
+        for (auto& task : request.tasks)
         {
             if (!task())
             {
@@ -190,8 +190,7 @@ bool StreamSendWorker::_sendImage(const ImageWrapper& image)
 {
     const auto sendFunc =
         std::bind(&StreamSendWorker::_sendSegment, this, std::placeholders::_1);
-    return _sendImageView(image.view) &&
-           _imageSegmenter.generate(image, sendFunc);
+    return _imageSegmenter.generate(image, sendFunc);
 }
 
 bool StreamSendWorker::_sendImageView(const View view)
@@ -202,6 +201,13 @@ bool StreamSendWorker::_sendImageView(const View view)
 
 bool StreamSendWorker::_sendSegment(const Segment& segment)
 {
+    if (segment.view != _currentView)
+    {
+        if (!_sendImageView(segment.view))
+            return false;
+        _currentView = segment.view;
+    }
+
     auto message = QByteArray{(const char*)(&segment.parameters),
                               sizeof(SegmentParameters)};
     message.append(segment.imageData);

--- a/deflect/StreamSendWorker.h
+++ b/deflect/StreamSendWorker.h
@@ -108,6 +108,7 @@ private:
     std::mutex _mutex;
     std::condition_variable _condition;
     bool _running = false;
+    View _currentView = View::mono;
 
     /** Main QThread loop doing asynchronous processing of queued tasks. */
     void run() final;

--- a/deflect/types.h
+++ b/deflect/types.h
@@ -54,7 +54,8 @@ enum class View : std::uint8_t
 {
     mono,
     left_eye,
-    right_eye
+    right_eye,
+    side_by_side
 };
 
 /** Sub-sampling of the image chrominance components in YCbCr color space. */

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#Changelog}
 
 ## Deflect 0.13 (git master)
 
+* [163](https://github.com/BlueBrain/Deflect/pull/163):
+  Stereo streaming accepts side-by-side images as input.
 * [161](https://github.com/BlueBrain/Deflect/pull/161):
   DesktopStreamer OSX: the default hosts are read from a json file in the app
   bundle. This is useful for external users who want to adapt the official


### PR DESCRIPTION
This is useful for applications like Brayns which render natively in
side-by-side format. Splitting the image into a left and right part
during the tiling process is more optimal and user-friendly than
asking the application to do it and make two send() calls.