### PR TITLE
Fix documentation plan: disable doxygen help extraction

### DIFF
--- a/apps/DesktopStreamer/CMakeLists.txt
+++ b/apps/DesktopStreamer/CMakeLists.txt
@@ -77,7 +77,7 @@ if(MSVC)
   list(APPEND DESKTOPSTREAMER_LINK_LIBRARIES Ws2_32)
 endif()
 
-common_application(${DESKTOPSTREAMER_APP_NAME} GUI)
+common_application(${DESKTOPSTREAMER_APP_NAME} GUI NOHELP)
 
 if(APPLE)
   # create a zip for Puppet deployment

--- a/apps/QmlStreamer/CMakeLists.txt
+++ b/apps/QmlStreamer/CMakeLists.txt
@@ -4,4 +4,4 @@
 
 set(QMLSTREAMER_SOURCES main.cpp resources.qrc)
 set(QMLSTREAMER_LINK_LIBRARIES DeflectQt)
-common_application(qmlstreamer)
+common_application(qmlstreamer NOHELP)


### PR DESCRIPTION
The QCommandLine parser needs a QGuiApplication to run correctly, but this one aborts immediately on CI machines without a DISPLAY where doxygen is run, failing the plan.