### PR TITLE
Fixing the proxy type error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #                          Daniel Nachbaur <daniel.nachbaur@epfl.ch>
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-project(Deflect VERSION 0.13.0)
+project(Deflect VERSION 0.13.1)
 set(Deflect_VERSION_ABI 6)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/common)

--- a/deflect/Server.cpp
+++ b/deflect/Server.cpp
@@ -44,6 +44,7 @@
 #include "NetworkProtocol.h"
 #include "ServerWorker.h"
 
+#include <QNetworkProxy>
 #include <QThread>
 #include <stdexcept>
 
@@ -60,9 +61,12 @@ public:
 Server::Server(const int port)
     : _impl(new Impl)
 {
+    setProxy(QNetworkProxy::NoProxy);
     if (!listen(QHostAddress::Any, port))
     {
-        const auto err = QString("could not listen on port: %1").arg(port);
+        const auto err = QString("could not listen on port: %1. QTcpServer: %2")
+                             .arg(port)
+                             .arg(QTcpServer::errorString());
         throw std::runtime_error(err.toStdString());
     }
 

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,11 @@ Changelog {#Changelog}
 
 ## Deflect 0.13
 
+### 0.13.1 (git master)
+
+* [173](https://github.com/BlueBrain/Deflect/pull/173):
+  Fix server: disabling system proxy which are default starting Qt 5.8
+
 ### Deflect 0.13.0 (10-05-2017)
 * [163](https://github.com/BlueBrain/Deflect/pull/163):
   Stereo streaming accepts side-by-side images as input.


### PR DESCRIPTION
Starting Qt 5.8 system proxy settings are used by default