### PR TITLE
Performance improvements for sending small images (tested with 64x64)

### DIFF
--- a/deflect/ImageJpegCompressor.h
+++ b/deflect/ImageJpegCompressor.h
@@ -71,6 +71,7 @@ public:
 
 private:
     tjhandle _tjHandle;
+    std::vector<unsigned char> _tjJpegBuf;
 };
 }
 

--- a/deflect/ImageSegmenter.h
+++ b/deflect/ImageSegmenter.h
@@ -91,6 +91,16 @@ public:
      */
     DEFLECT_API void setNominalSegmentDimensions(uint width, uint height);
 
+    /**
+     * For a small input image (tested with 64x64, possible for <=512 as well),
+     * directly compress it to a single segment which will be enqueued for
+     * sending.
+     *
+     * @param image The image to be compressed
+     * @return the compressed segment
+     */
+    DEFLECT_API Segment compressSingleSegment(const ImageWrapper& image);
+
 private:
     struct SegmentationInfo
     {
@@ -105,7 +115,7 @@ private:
     };
 
     bool _generateJpeg(const ImageWrapper& image, const Handler& handler);
-    void _computeJpeg(Segment& task);
+    void _computeJpeg(Segment& task, bool sendSegment);
     bool _generateRaw(const ImageWrapper& image, const Handler& handler) const;
 
     Segments _generateSegments(const ImageWrapper& image) const;

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -5,6 +5,9 @@ Changelog {#Changelog}
 
 ### 0.13.1 (git master)
 
+* [174](https://github.com/BlueBrain/Deflect/pull/174):
+  Performance improvements for sending small images (tested with 64x64):
+  directly compress them in the call thread
 * [173](https://github.com/BlueBrain/Deflect/pull/173):
   Fix server: disabling system proxy which are default starting Qt 5.8
 


### PR DESCRIPTION
- directly compress them in the call thread
- keep JPEG out buffer allocated to save one memory allocation