### PR TITLE
Various fixes

### DIFF
--- a/deflect/ImageJpegCompressor.cpp
+++ b/deflect/ImageJpegCompressor.cpp
@@ -100,6 +100,14 @@ QByteArray ImageJpegCompressor::computeJpeg(const ImageWrapper& sourceImage,
     // though it does not modify it. It can "safely" be cast to non-const
     // pointer to comply with the incorrect API.
     unsigned char* tjSrcBuffer = (unsigned char*)sourceImage.data;
+    if (!tjSrcBuffer)
+    {
+        std::cerr
+            << "libjpeg-turbo image conversion failure: source image is NULL"
+            << std::endl;
+        return QByteArray();
+    }
+
     tjSrcBuffer +=
         imageRegion.y() * sourceImage.width * sourceImage.getBytesPerPixel();
     tjSrcBuffer += imageRegion.x() * sourceImage.getBytesPerPixel();
@@ -124,7 +132,8 @@ QByteArray ImageJpegCompressor::computeJpeg(const ImageWrapper& sourceImage,
                           tjJpegQual, tjFlags);
     if (err != 0)
     {
-        std::cerr << "libjpeg-turbo image conversion failure" << std::endl;
+        std::cerr << "libjpeg-turbo image conversion failure: "
+                  << tjGetErrorStr() << std::endl;
         return QByteArray();
     }
 

--- a/deflect/ImageJpegCompressor.h
+++ b/deflect/ImageJpegCompressor.h
@@ -65,6 +65,7 @@ public:
      * @param sourceImage The source image containing uncompressed image data.
      * @param imageRegion The region of the image to be compressed. Must not
      *        exceed image dimensions.
+     * @return compressed image if successful, otherwise QByteArray.isEmpty()
      */
     DEFLECT_API QByteArray computeJpeg(const ImageWrapper& sourceImage,
                                        const QRect& imageRegion);

--- a/deflect/ImageJpegCompressor.h
+++ b/deflect/ImageJpegCompressor.h
@@ -65,7 +65,9 @@ public:
      * @param sourceImage The source image containing uncompressed image data.
      * @param imageRegion The region of the image to be compressed. Must not
      *        exceed image dimensions.
-     * @return compressed image if successful, otherwise QByteArray.isEmpty()
+     * @return compressed image
+     * @throw std::invalid_argument if sourceImage.data is nullptr
+     * @throw std::runtime_error if JPEG compression failed
      */
     DEFLECT_API QByteArray computeJpeg(const ImageWrapper& sourceImage,
                                        const QRect& imageRegion);

--- a/deflect/ImageSegmenter.h
+++ b/deflect/ImageSegmenter.h
@@ -98,6 +98,9 @@ public:
      *
      * @param image The image to be compressed
      * @return the compressed segment
+     * @throw std::invalid_argument if image is too big or invalid JPEG
+     *                              compression arguments
+     * @throw std::runtime_error if JPEG compression failed
      * @threadsafe
      */
     DEFLECT_API Segment createSingleSegment(const ImageWrapper& image);

--- a/deflect/ImageSegmenter.h
+++ b/deflect/ImageSegmenter.h
@@ -100,7 +100,7 @@ public:
      * @return the compressed segment
      * @threadsafe
      */
-    DEFLECT_API Segment compressSingleSegment(const ImageWrapper& image);
+    DEFLECT_API Segment createSingleSegment(const ImageWrapper& image);
 
 private:
     struct SegmentationInfo

--- a/deflect/ImageWrapper.h
+++ b/deflect/ImageWrapper.h
@@ -124,7 +124,7 @@ struct ImageWrapper
     //@{
     CompressionPolicy compressionPolicy; /**< Is the image to be compressed
                                               (default: auto). @version 1.0 */
-    unsigned int compressionQuality;     /**< Compression quality (0 worst,
+    unsigned int compressionQuality;     /**< Compression quality (1 worst,
                                               100 best, default: 75).
                                               @version 1.0 */
     ChromaSubsampling subsampling;       /**< Chrominance sub-sampling.

--- a/deflect/Observer.cpp
+++ b/deflect/Observer.cpp
@@ -169,4 +169,16 @@ void Observer::setDisconnectedCallback(const std::function<void()> callback)
 {
     _impl->disconnectedCallback = callback;
 }
+
+void Observer::sendSizeHints(const SizeHints& hints)
+{
+    _impl->sendWorker.enqueueSizeHints(hints);
+}
+
+bool Observer::sendData(const char* data, const size_t count)
+{
+    return _impl->sendWorker
+        .enqueueData(QByteArray::fromRawData(data, int(count)))
+        .get();
+}
 }

--- a/deflect/Observer.cpp
+++ b/deflect/Observer.cpp
@@ -40,6 +40,7 @@
 /*********************************************************************/
 
 #include "Observer.h"
+#include "NetworkProtocol.h"
 #include "StreamPrivate.h"
 
 #include <QDataStream>
@@ -49,8 +50,10 @@
 
 namespace deflect
 {
-Observer::Observer()
-    : _impl(new StreamPrivate("", "", Socket::defaultPortNumber, true))
+const unsigned short Observer::defaultPortNumber = DEFAULT_PORT_NUMBER;
+
+Observer::Observer(const unsigned short port)
+    : _impl(new StreamPrivate("", "", port, true))
 {
 }
 

--- a/deflect/Observer.h
+++ b/deflect/Observer.h
@@ -199,6 +199,27 @@ public:
      */
     DEFLECT_API void setDisconnectedCallback(std::function<void()> callback);
 
+    /**
+     * Send size hints to the stream server to indicate sizes that should be
+     * respected by resize operations on the server side.
+     *
+     * @note blocks until all pending asynchonous send operations are finished.
+     * @param hints the new size hints for the server
+     * @version 1.2
+     */
+    DEFLECT_API void sendSizeHints(const SizeHints& hints);
+
+    /**
+     * Send data to the Server.
+     *
+     * @note blocks until all pending asynchonous send operations are finished.
+     * @param data the pointer to the data buffer.
+     * @param count the number of bytes to send.
+     * @return true if the data could be sent, false otherwise
+     * @version 1.3
+     */
+    DEFLECT_API bool sendData(const char* data, size_t count);
+
 protected:
     Observer(const Observer&) = delete;
     const Observer& operator=(const Observer&) = delete;

--- a/deflect/Observer.h
+++ b/deflect/Observer.h
@@ -69,16 +69,21 @@ class StreamPrivate;
 class Observer
 {
 public:
+    /** The default communication port */
+    static const unsigned short defaultPortNumber;
+
     /**
      * Open a new connection to the Server using environment variables.
      *
      * DEFLECT_HOST  The address of the target Server instance (required).
      * DEFLECT_ID    The identifier for the stream. If not provided, a random
      *               unique identifier will be used.
-     * @throw std::runtime_error if DEFLECT_HOST was not provided.
+     * @param port Port of the Server instance, default 1701.
+     * @throw std::runtime_error if DEFLECT_HOST was not provided or no
+     *                           connection to server could be established
      * @version 1.3
      */
-    DEFLECT_API Observer();
+    DEFLECT_API explicit Observer(unsigned short port = defaultPortNumber);
 
     /**
      * Open a new connection to the Server.
@@ -97,11 +102,12 @@ public:
      *             "192.168.1.83". If left empty, the environment variable
      *             DEFLECT_HOST will be used instead.
      * @param port Port of the Server instance, default 1701.
-     * @throw std::runtime_error if no host was provided.
+     * @throw std::runtime_error if no host was provided or no
+     *                           connection to server could be established
      * @version 1.0
      */
     DEFLECT_API Observer(const std::string& id, const std::string& host,
-                         unsigned short port = 1701);
+                         unsigned short port = defaultPortNumber);
 
     /** Destruct the Observer, closing the connection. @version 1.0 */
     DEFLECT_API virtual ~Observer();

--- a/deflect/Segment.h
+++ b/deflect/Segment.h
@@ -63,6 +63,9 @@ struct Segment
 
     /** @internal raw, uncompressed source image, used for compression */
     const ImageWrapper* sourceImage = nullptr;
+
+    /** @internal holds potential exception from compression thread */
+    std::exception_ptr exception;
 };
 }
 

--- a/deflect/Socket.cpp
+++ b/deflect/Socket.cpp
@@ -57,8 +57,6 @@ const int RECEIVE_TIMEOUT_MS = 1000;
 
 namespace deflect
 {
-const unsigned short Socket::defaultPortNumber = DEFAULT_PORT_NUMBER;
-
 Socket::Socket(const std::string& host, const unsigned short port)
     : _host(host)
     , _socket(new QTcpSocket(this)) // Ensure that _socket parent is

--- a/deflect/Socket.h
+++ b/deflect/Socket.h
@@ -66,16 +66,12 @@ class Socket : public QObject
     Q_OBJECT
 
 public:
-    /** The default communication port */
-    static const unsigned short defaultPortNumber;
-
     /**
      * Construct a Socket and connect to host.
      * @param host The target host (IP address or hostname)
      * @param port The target port
      */
-    DEFLECT_API Socket(const std::string& host,
-                       unsigned short port = defaultPortNumber);
+    DEFLECT_API Socket(const std::string& host, unsigned short port);
 
     /** Destruct a Socket, disconnecting from host. */
     DEFLECT_API ~Socket() = default;

--- a/deflect/Stream.cpp
+++ b/deflect/Stream.cpp
@@ -73,16 +73,4 @@ Stream::Future Stream::sendAndFinish(const ImageWrapper& image)
 {
     return _impl->sendWorker.enqueueImage(image, true);
 }
-
-void Stream::sendSizeHints(const SizeHints& hints)
-{
-    _impl->sendWorker.enqueueSizeHints(hints);
-}
-
-bool Stream::sendData(const char* data, const size_t count)
-{
-    return _impl->sendWorker
-        .enqueueData(QByteArray::fromRawData(data, int(count)))
-        .get();
-}
 }

--- a/deflect/Stream.cpp
+++ b/deflect/Stream.cpp
@@ -44,8 +44,8 @@
 
 namespace deflect
 {
-Stream::Stream()
-    : Observer(new StreamPrivate("", "", Socket::defaultPortNumber, false))
+Stream::Stream(const unsigned short port)
+    : Observer(new StreamPrivate("", "", port, false))
 {
 }
 

--- a/deflect/Stream.h
+++ b/deflect/Stream.h
@@ -111,6 +111,10 @@ public:
      * @param image The image to send. Note that the image is not copied, so the
      *              referenced must remain valid until the send is finished.
      * @return true if the image data could be sent, false otherwise
+     * @throw std::invalid_argument if RGBA and uncompressed
+     * @throw std::invalid_argument if invalid JPEG compression arguments
+     * @throw std::runtime_error if pending finishFrame() has not been completed
+     * @throw std::runtime_error if JPEG compression failed
      * @version 1.6
      * @sa finishFrame()
      */
@@ -140,6 +144,10 @@ public:
      * @param image The image to send. Note that the image is not copied, so the
      *              referenced must remain valid until the send is finished
      * @return true if the image data could be sent, false otherwise.
+     * @throw std::invalid_argument if RGBA and uncompressed
+     * @throw std::invalid_argument if invalid JPEG compression arguments
+     * @throw std::runtime_error if pending finishFrame() has not been completed
+     * @throw std::runtime_error if JPEG compression failed
      * @see send()
      * @version 1.6
      */

--- a/deflect/Stream.h
+++ b/deflect/Stream.h
@@ -149,27 +149,6 @@ public:
     Future asyncSend(const ImageWrapper& image) { return sendAndFinish(image); }
     //@}
 
-    /**
-     * Send size hints to the stream server to indicate sizes that should be
-     * respected by resize operations on the server side.
-     *
-     * @note blocks until all pending asynchonous send operations are finished.
-     * @param hints the new size hints for the server
-     * @version 1.2
-     */
-    DEFLECT_API void sendSizeHints(const SizeHints& hints);
-
-    /**
-     * Send data to the Server.
-     *
-     * @note blocks until all pending asynchonous send operations are finished.
-     * @param data the pointer to the data buffer.
-     * @param count the number of bytes to send.
-     * @return true if the data could be sent, false otherwise
-     * @version 1.3
-     */
-    DEFLECT_API bool sendData(const char* data, size_t count);
-
 private:
     Stream(const Stream&) = delete;
     const Stream& operator=(const Stream&) = delete;

--- a/deflect/Stream.h
+++ b/deflect/Stream.h
@@ -68,10 +68,12 @@ public:
      * DEFLECT_HOST  The address of the target Server instance (required).
      * DEFLECT_ID    The identifier for the stream. If not provided, a random
      *               unique identifier will be used.
-     * @throw std::runtime_error if DEFLECT_HOST was not provided.
+     * @param port Port of the Server instance, default 1701.
+     * @throw std::runtime_error if DEFLECT_HOST was not provided or no
+     *                           connection to server could be established
      * @version 1.3
      */
-    DEFLECT_API Stream();
+    DEFLECT_API explicit Stream(unsigned short port = defaultPortNumber);
 
     /**
      * Open a new connection to the Server.
@@ -91,11 +93,12 @@ public:
      *             "192.168.1.83". If left empty, the environment variable
      *             DEFLECT_HOST will be used instead.
      * @param port Port of the Server instance, default 1701.
-     * @throw std::runtime_error if no host was provided.
+     * @throw std::runtime_error if no host was provided or no
+     *                           connection to server could be established
      * @version 1.0
      */
     DEFLECT_API Stream(const std::string& id, const std::string& host,
-                       unsigned short port = 1701);
+                       unsigned short port = defaultPortNumber);
 
     /** Destruct the Stream, closing the connection. @version 1.0 */
     DEFLECT_API virtual ~Stream();

--- a/deflect/StreamPrivate.cpp
+++ b/deflect/StreamPrivate.cpp
@@ -86,7 +86,8 @@ StreamPrivate::StreamPrivate(const std::string& id_, const std::string& host,
     , sendWorker{socket, id}
 {
     if (!socket.isConnected())
-        return;
+        throw std::runtime_error(
+            "Connection to deflect server could not be established");
 
     socket.connect(&socket, &Socket::disconnected, [this]() {
         if (disconnectedCallback)

--- a/deflect/StreamSendWorker.cpp
+++ b/deflect/StreamSendWorker.cpp
@@ -167,16 +167,15 @@ Stream::Future StreamSendWorker::enqueueImage(const ImageWrapper& image,
 {
     if (_pendingFinish)
     {
-        return make_exception_future<bool>(std::make_exception_ptr(
-            std::runtime_error("Pending finish, no send allowed")));
+        return make_exception_future<bool>(
+            std::runtime_error("Pending finish, no send allowed"));
     }
 
     if (image.compressionPolicy != COMPRESSION_ON && image.pixelFormat != RGBA)
     {
-        return make_exception_future<bool>(
-            std::make_exception_ptr(std::invalid_argument(
-                "Currently, RAW images can only be sent in RGBA format. Other "
-                "formats support remain to be implemented.")));
+        return make_exception_future<bool>(std::invalid_argument(
+            "Currently, RAW images can only be sent in RGBA format. Other "
+            "formats support remain to be implemented."));
     }
 
     if (image.compressionPolicy == COMPRESSION_ON)
@@ -187,7 +186,7 @@ Stream::Future StreamSendWorker::enqueueImage(const ImageWrapper& image,
             msg << "JPEG compression quality must be between 1 and 100, got "
                 << image.compressionQuality << std::endl;
             return make_exception_future<bool>(
-                std::make_exception_ptr(std::invalid_argument(msg.str())));
+                std::invalid_argument(msg.str()));
         }
     }
 

--- a/deflect/types.h
+++ b/deflect/types.h
@@ -82,11 +82,16 @@ std::future<T> make_ready_future(T&& value)
 }
 
 template <typename T>
-std::future<T> make_exception_future(std::exception_ptr exc)
+std::future<T> make_exception_future(std::exception_ptr&& e)
 {
     std::promise<T> promise;
-    promise.set_exception(exc);
+    promise.set_exception(std::move(e));
     return promise.get_future();
+}
+template <typename T, typename Exception>
+std::future<T> make_exception_future(Exception&& e)
+{
+    return make_exception_future<T>(std::make_exception_ptr(std::move(e)));
 }
 
 class EventReceiver;

--- a/deflect/types.h
+++ b/deflect/types.h
@@ -81,6 +81,14 @@ std::future<T> make_ready_future(T&& value)
     return promise.get_future();
 }
 
+template <typename T>
+std::future<T> make_exception_future(std::exception_ptr exc)
+{
+    std::promise<T> promise;
+    promise.set_exception(exc);
+    return promise.get_future();
+}
+
 class EventReceiver;
 class Frame;
 class FrameDispatcher;

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -5,6 +5,8 @@ Changelog {#Changelog}
 
 ### 0.14.0 (git master)
 
+* [177](https://github.com/BlueBrain/Deflect/pull/177):
+  Catch errors regarding invalid JPEG quality values
 * [176](https://github.com/BlueBrain/Deflect/pull/176):
   OPT: Lock-free request queueing for multi-threaded stream clients (e.g. KNL)
 * [175](https://github.com/BlueBrain/Deflect/pull/175):

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -6,7 +6,9 @@ Changelog {#Changelog}
 ### 0.14.0 (git master)
 
 * [177](https://github.com/BlueBrain/Deflect/pull/177):
-  Catch errors regarding invalid JPEG quality values
+  Improve stream error handling
+  * Catch errors regarding invalid JPEG quality values
+  * Set exceptions in returned futures on errors
 * [176](https://github.com/BlueBrain/Deflect/pull/176):
   OPT: Lock-free request queueing for multi-threaded stream clients (e.g. KNL)
 * [175](https://github.com/BlueBrain/Deflect/pull/175):

--- a/tests/cpp/ServerTests.cpp
+++ b/tests/cpp/ServerTests.cpp
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE(testCompressionErrorForBigNullImage)
 
         deflect::ImageWrapper bigImage(nullptr, 1000, 1000, deflect::ARGB);
         bigImage.compressionPolicy = deflect::COMPRESSION_ON;
-        BOOST_CHECK(!stream.send(bigImage).get());
+        BOOST_CHECK_THROW(stream.send(bigImage).get(), std::invalid_argument);
     }
 
     // handle close of streamer

--- a/tests/cpp/ServerTests.cpp
+++ b/tests/cpp/ServerTests.cpp
@@ -41,19 +41,13 @@
 #include <boost/test/unit_test.hpp>
 namespace ut = boost::unit_test;
 
+#include "DeflectServer.h"
 #include "MinimalGlobalQtApp.h"
 
-#include <deflect/EventReceiver.h>
 #include <deflect/Frame.h>
-#include <deflect/Server.h>
 #include <deflect/Stream.h>
 
 #include <cmath>
-#include <iostream>
-
-#include <QMutex>
-#include <QThread>
-#include <QWaitCondition>
 
 namespace
 {
@@ -62,279 +56,105 @@ const QString testStreamId("teststream");
 
 BOOST_GLOBAL_FIXTURE(MinimalGlobalQtApp);
 
+BOOST_FIXTURE_TEST_SUITE(server, DeflectServer)
+
 BOOST_AUTO_TEST_CASE(testSizeHintsReceivedByServer)
 {
-    QThread serverThread;
-    deflect::Server* server = new deflect::Server(0 /* OS-chosen port */);
-    server->moveToThread(&serverThread);
-    serverThread.connect(&serverThread, &QThread::finished, server,
-                         &deflect::Server::deleteLater);
-    serverThread.start();
-
-    QWaitCondition received;
-    QMutex mutex;
-
     deflect::SizeHints testHints;
     testHints.maxWidth = 500;
     testHints.preferredHeight = 200;
 
-    QString streamId;
-    deflect::SizeHints sizeHints;
-
-    bool receivedState = false;
-    server->connect(server, &deflect::Server::receivedSizeHints,
-                    [&](const QString id, const deflect::SizeHints hints) {
-                        streamId = id;
-                        sizeHints = hints;
-                        mutex.lock();
-                        receivedState = true;
-                        received.wakeAll();
-                        mutex.unlock();
-                    });
+    bool received = false;
+    setSizeHintsCallback([&](const QString id, const deflect::SizeHints hints) {
+        BOOST_CHECK_EQUAL(id.toStdString(), testStreamId.toStdString());
+        BOOST_CHECK(hints == testHints);
+        received = true;
+    });
 
     {
         deflect::Stream stream(testStreamId.toStdString(), "localhost",
-                               server->serverPort());
+                               serverPort());
         BOOST_CHECK(stream.isConnected());
         stream.sendSizeHints(testHints);
-
-        for (size_t i = 0; i < 20; ++i)
-        {
-            mutex.lock();
-            received.wait(&mutex, 100 /*ms*/);
-            if (receivedState)
-            {
-                BOOST_CHECK_EQUAL(streamId.toStdString(),
-                                  testStreamId.toStdString());
-                BOOST_CHECK(sizeHints == testHints);
-
-                serverThread.quit();
-                serverThread.wait();
-                mutex.unlock();
-                return;
-            }
-            mutex.unlock();
-        }
-        BOOST_CHECK(!"reachable");
+        waitForMessage();
     }
+
+    waitForMessage();
+    BOOST_CHECK_EQUAL(getOpenedStreams(), 0);
+    BOOST_CHECK(received);
 }
 
 BOOST_AUTO_TEST_CASE(testRegisterForEventReceivedByServer)
 {
-    QThread serverThread;
-    deflect::Server* server = new deflect::Server(0 /* OS-chosen port */);
-    server->moveToThread(&serverThread);
-    serverThread.connect(&serverThread, &QThread::finished, server,
-                         &deflect::Server::deleteLater);
-    serverThread.start();
-
-    QWaitCondition received;
-    QMutex mutex;
-
-    QString streamId;
-    bool exclusiveBind = false;
-    deflect::EventReceiver* eventReceiver = nullptr;
-
-    bool receivedState = false;
-    server->connect(server, &deflect::Server::registerToEvents,
-                    [&](const QString id, const bool exclusive,
-                        deflect::EventReceiver* receiver,
-                        deflect::BoolPromisePtr success) {
-                        streamId = id;
-                        exclusiveBind = exclusive;
-                        eventReceiver = receiver;
-                        success->set_value(true);
-                        mutex.lock();
-                        receivedState = true;
-                        received.wakeAll();
-                        mutex.unlock();
-                    });
+    bool received = false;
+    setRegisterToEventsCallback([&](const QString id, const bool exclusive,
+                                    deflect::EventReceiver* eventReceiver) {
+        BOOST_CHECK_EQUAL(id.toStdString(), testStreamId.toStdString());
+        BOOST_CHECK(exclusive);
+        BOOST_CHECK(eventReceiver);
+        received = true;
+    });
 
     {
         deflect::Stream stream(testStreamId.toStdString(), "localhost",
-                               server->serverPort());
+                               serverPort());
         BOOST_REQUIRE(stream.isConnected());
         BOOST_CHECK(stream.registerForEvents(true));
+        waitForMessage();
     }
 
-    for (size_t i = 0; i < 20; ++i)
-    {
-        mutex.lock();
-        received.wait(&mutex, 100 /*ms*/);
-        if (receivedState)
-        {
-            BOOST_CHECK_EQUAL(streamId.toStdString(),
-                              testStreamId.toStdString());
-            BOOST_CHECK(exclusiveBind);
-            BOOST_CHECK(eventReceiver);
-
-            serverThread.quit();
-            serverThread.wait();
-            mutex.unlock();
-            return;
-        }
-        mutex.unlock();
-    }
-    BOOST_CHECK(!"reachable");
+    waitForMessage();
+    BOOST_CHECK_EQUAL(getOpenedStreams(), 0);
+    BOOST_CHECK(received);
 }
 
 BOOST_AUTO_TEST_CASE(testDataReceivedByServer)
 {
-    if (getenv("TRAVIS"))
-    {
-        std::cout << "ignore testDataReceivedByServer on Jenkins" << std::endl;
-        return;
-    }
-
-    QThread serverThread;
-    deflect::Server* server = new deflect::Server(0 /* OS-chosen port */);
-    server->moveToThread(&serverThread);
-    serverThread.connect(&serverThread, &QThread::finished, server,
-                         &deflect::Server::deleteLater);
-    serverThread.start();
-
-    QWaitCondition received;
-    QMutex mutex;
-
-    QString streamId;
-    std::string receivedData;
     const auto sentData = std::string{"Hello World!"};
 
-    bool receivedState = false;
-    server->connect(server, &deflect::Server::receivedData,
-                    [&](const QString id, QByteArray data) {
-                        streamId = id;
-                        receivedData = QString(data).toStdString();
-                        mutex.lock();
-                        receivedState = true;
-                        received.wakeAll();
-                        mutex.unlock();
-                    });
+    bool received = false;
+    setDataReceivedCallback([&](const QString id, QByteArray data) {
+        BOOST_CHECK_EQUAL(id.toStdString(), testStreamId.toStdString());
+        BOOST_CHECK_EQUAL(data.toStdString(), sentData);
+        received = true;
+    });
 
     {
         deflect::Stream stream(testStreamId.toStdString(), "localhost",
-                               server->serverPort());
+                               serverPort());
         BOOST_REQUIRE(stream.isConnected());
         stream.sendData(sentData.data(), sentData.size());
+        waitForMessage();
     }
 
-    for (size_t i = 0; i < 20; ++i)
-    {
-        mutex.lock();
-        received.wait(&mutex, 100 /*ms*/);
-        if (receivedState)
-        {
-            BOOST_CHECK_EQUAL(streamId.toStdString(),
-                              testStreamId.toStdString());
-            BOOST_CHECK_EQUAL(receivedData, sentData);
-
-            serverThread.quit();
-            serverThread.wait();
-            mutex.unlock();
-            return;
-        }
-        mutex.unlock();
-    }
-    BOOST_CHECK(!"reachable");
+    waitForMessage();
+    BOOST_CHECK_EQUAL(getOpenedStreams(), 0);
+    BOOST_CHECK(received);
 }
 
 BOOST_AUTO_TEST_CASE(testOneObserverAndOneStream)
 {
-    QThread serverThread;
-    deflect::Server* server = new deflect::Server(0 /* OS-chosen port */);
-    server->moveToThread(&serverThread);
-    serverThread.connect(&serverThread, &QThread::finished, server,
-                         &deflect::Server::deleteLater);
-    serverThread.start();
-
-    // to wait in this thread until server thread is done with certain
-    // operations
-    QWaitCondition received;
-    QMutex mutex;
-    bool receivedState = false;
-
-    auto processServerMessages = [&] {
-        for (size_t j = 0; j < 20; ++j)
-        {
-            mutex.lock();
-            received.wait(&mutex, 100 /*ms*/);
-            if (receivedState)
-            {
-                mutex.unlock();
-                break;
-            }
-            mutex.unlock();
-        }
-        BOOST_REQUIRE(receivedState);
-        receivedState = false;
-    };
-
-    size_t openedStreams = 0;
-
-    // only continue once we have the stream, whichever comes first
-    server->connect(server, &deflect::Server::pixelStreamOpened,
-                    [&](const QString) {
-                        ++openedStreams;
-                        if (openedStreams == 1)
-                        {
-                            mutex.lock();
-                            receivedState = true;
-                            received.wakeAll();
-                            mutex.unlock();
-                        }
-                    });
-
-    // make sure that we get the close of the stream and the observer
-    server->connect(server, &deflect::Server::pixelStreamClosed,
-                    [&](const QString) {
-                        --openedStreams;
-                        if (openedStreams == 0)
-                        {
-                            mutex.lock();
-                            receivedState = true;
-                            received.wakeAll();
-                            mutex.unlock();
-                        }
-                    });
-
-    // register to events to test the observer's purpose
-    deflect::EventReceiver* eventReceiver = nullptr;
-    server->connect(server, &deflect::Server::registerToEvents,
-                    [&](const QString, const bool,
-                        deflect::EventReceiver* evtReceiver,
-                        deflect::BoolPromisePtr success) {
-                        eventReceiver = evtReceiver;
-                        success->set_value(true);
-                    });
+    setFrameReceivedCallback([&](deflect::FramePtr frame) {
+        BOOST_CHECK_EQUAL(frame->segments.size(), 1);
+        BOOST_CHECK_EQUAL(frame->uri.toStdString(), testStreamId.toStdString());
+    });
 
     // handle received frames to test the stream's purpose
     const size_t expectedFrames = 2;
-    size_t receivedFrames = 0;
-    server->connect(server, &deflect::Server::receivedFrame,
-                    [&](deflect::FramePtr frame) {
-                        BOOST_CHECK_EQUAL(frame->segments.size(), 1);
-                        BOOST_CHECK_EQUAL(frame->uri.toStdString(),
-                                          testStreamId.toStdString());
-                        ++receivedFrames;
-                        mutex.lock();
-                        receivedState = true;
-                        received.wakeAll();
-                        mutex.unlock();
-                    });
 
     {
         deflect::Stream stream(testStreamId.toStdString(), "localhost",
-                               server->serverPort());
+                               serverPort());
         BOOST_REQUIRE(stream.isConnected());
 
         deflect::Observer observer(testStreamId.toStdString(), "localhost",
-                                   server->serverPort());
+                                   serverPort());
         BOOST_REQUIRE(observer.isConnected());
 
         BOOST_CHECK(observer.registerForEvents(true));
 
         // handle connects first before sending and receiving frames
-        processServerMessages();
+        waitForMessage();
 
         const unsigned int width = 4;
         const unsigned int height = 4;
@@ -350,14 +170,13 @@ BOOST_AUTO_TEST_CASE(testOneObserverAndOneStream)
         // are received accordingly
         for (size_t i = 0; i < expectedFrames; ++i)
         {
-            receivedState = false;
             stream.sendAndFinish(image).wait();
-            server->requestFrame(testStreamId);
+            requestFrame(testStreamId);
             event.key = i;
-            eventReceiver->processEvent(event);
+            processEvent(event);
 
             // process event sending first before receiving in observer
-            processServerMessages();
+            waitForMessage();
 
             while (!observer.hasEvent())
                 ;
@@ -369,46 +188,14 @@ BOOST_AUTO_TEST_CASE(testOneObserverAndOneStream)
     }
 
     // handle close of streamer and observer
-    processServerMessages();
+    waitForMessage();
 
-    serverThread.quit();
-    serverThread.wait();
-
-    BOOST_CHECK_EQUAL(openedStreams, 0);
-    BOOST_CHECK_EQUAL(receivedFrames, expectedFrames);
+    BOOST_CHECK_EQUAL(getOpenedStreams(), 0);
+    BOOST_CHECK_EQUAL(getReceivedFrames(), expectedFrames);
 }
 
 BOOST_AUTO_TEST_CASE(testThreadedSmallSegmentStream)
 {
-    QThread serverThread;
-    deflect::Server* server = new deflect::Server(0 /* OS-chosen port */);
-    server->moveToThread(&serverThread);
-    serverThread.connect(&serverThread, &QThread::finished, server,
-                         &deflect::Server::deleteLater);
-    serverThread.start();
-
-    // to wait in this thread until server thread is done with certain
-    // operations
-    QWaitCondition received;
-    QMutex mutex;
-    bool receivedState = false;
-
-    auto processServerMessages = [&] {
-        for (size_t j = 0; j < 20; ++j)
-        {
-            mutex.lock();
-            received.wait(&mutex, 100 /*ms*/);
-            if (receivedState)
-            {
-                mutex.unlock();
-                break;
-            }
-            mutex.unlock();
-        }
-        BOOST_REQUIRE(receivedState);
-        receivedState = false;
-    };
-
     const unsigned int segmentSize = 64;
     const unsigned int width = 1920;
     const unsigned int height = 1088;
@@ -430,66 +217,30 @@ BOOST_AUTO_TEST_CASE(testThreadedSmallSegmentStream)
                         std::ceil((float)width / segmentSize) *
                             std::ceil((float)height / segmentSize));
 
+    setFrameReceivedCallback([&](deflect::FramePtr frame) {
+        BOOST_CHECK_EQUAL(frame->segments.size(), numSegments);
+        BOOST_CHECK_EQUAL(frame->uri.toStdString(), testStreamId.toStdString());
+        const auto dim = frame->computeDimensions();
+        BOOST_CHECK_EQUAL(dim.width(), width);
+        BOOST_CHECK_EQUAL(dim.height(), height);
+    });
+
     const std::vector<uint8_t> pixels(segmentSize * segmentSize * 4, 42);
-
-    size_t openedStreams = 0;
-    // only continue once we have the stream
-    server->connect(server, &deflect::Server::pixelStreamOpened,
-                    [&](const QString) {
-                        ++openedStreams;
-                        if (openedStreams == 1)
-                        {
-                            mutex.lock();
-                            receivedState = true;
-                            received.wakeAll();
-                            mutex.unlock();
-                        }
-                    });
-
-    // make sure that we get the close of the stream
-    server->connect(server, &deflect::Server::pixelStreamClosed,
-                    [&](const QString) {
-                        --openedStreams;
-                        if (openedStreams == 0)
-                        {
-                            mutex.lock();
-                            receivedState = true;
-                            received.wakeAll();
-                            mutex.unlock();
-                        }
-                    });
 
     // handle received frames to test the stream's purpose
     const size_t expectedFrames = 10;
-    size_t receivedFrames = 0;
-    server->connect(server, &deflect::Server::receivedFrame,
-                    [&](deflect::FramePtr frame) {
-                        BOOST_CHECK_EQUAL(frame->segments.size(), numSegments);
-                        BOOST_CHECK_EQUAL(frame->uri.toStdString(),
-                                          testStreamId.toStdString());
-                        const auto dim = frame->computeDimensions();
-                        BOOST_CHECK_EQUAL(dim.width(), width);
-                        BOOST_CHECK_EQUAL(dim.height(), height);
-                        ++receivedFrames;
-                        mutex.lock();
-                        receivedState = true;
-                        received.wakeAll();
-                        mutex.unlock();
-                    });
 
     {
         deflect::Stream stream(testStreamId.toStdString(), "localhost",
-                               server->serverPort());
+                               serverPort());
         BOOST_REQUIRE(stream.isConnected());
 
         // handle connects first before sending and receiving frames
-        processServerMessages();
+        waitForMessage();
 
         std::mutex testMutex; // BOOST_CHECK is not thread-safe
         for (size_t i = 0; i < expectedFrames; ++i)
         {
-            receivedState = false;
-
 // to make coverage report work; otherwise fails for unknown reasons
 #ifdef NDEBUG
 #pragma omp parallel for
@@ -510,87 +261,32 @@ BOOST_AUTO_TEST_CASE(testThreadedSmallSegmentStream)
 
             BOOST_CHECK(stream.finishFrame().get());
 
-            server->requestFrame(testStreamId);
+            requestFrame(testStreamId);
 
             // process frame receive
-            processServerMessages();
+            waitForMessage();
         }
     }
 
     // handle close of streamer
-    processServerMessages();
+    waitForMessage();
 
-    serverThread.quit();
-    serverThread.wait();
-
-    BOOST_CHECK_EQUAL(openedStreams, 0);
-    BOOST_CHECK_EQUAL(receivedFrames, expectedFrames);
+    BOOST_CHECK_EQUAL(getOpenedStreams(), 0);
+    BOOST_CHECK_EQUAL(getReceivedFrames(), expectedFrames);
 }
 
 BOOST_AUTO_TEST_CASE(testCompressionErrorForBigNullImage)
 {
-    QThread serverThread;
-    deflect::Server* server = new deflect::Server(0 /* OS-chosen port */);
-    server->moveToThread(&serverThread);
-    serverThread.connect(&serverThread, &QThread::finished, server,
-                         &deflect::Server::deleteLater);
-    serverThread.start();
+    deflect::Stream stream(testStreamId.toStdString(), "localhost",
+                           serverPort());
+    BOOST_REQUIRE(stream.isConnected());
 
-    // to wait in this thread until server thread is done with certain
-    // operations
-    QWaitCondition received;
-    QMutex mutex;
-    bool receivedState = false;
+    // handle connect of stream
+    waitForMessage();
 
-    auto processServerMessages = [&] {
-        for (size_t j = 0; j < 20; ++j)
-        {
-            mutex.lock();
-            received.wait(&mutex, 100 /*ms*/);
-            if (receivedState)
-            {
-                mutex.unlock();
-                break;
-            }
-            mutex.unlock();
-        }
-        BOOST_REQUIRE(receivedState);
-        receivedState = false;
-    };
-
-    // only continue once we have the stream
-    server->connect(server, &deflect::Server::pixelStreamOpened,
-                    [&](const QString) {
-                        mutex.lock();
-                        receivedState = true;
-                        received.wakeAll();
-                        mutex.unlock();
-                    });
-
-    // make sure that we get the close of the stream
-    server->connect(server, &deflect::Server::pixelStreamClosed,
-                    [&](const QString) {
-                        mutex.lock();
-                        receivedState = true;
-                        received.wakeAll();
-                        mutex.unlock();
-                    });
-
-    {
-        deflect::Stream stream(testStreamId.toStdString(), "localhost",
-                               server->serverPort());
-        BOOST_REQUIRE(stream.isConnected());
-
-        processServerMessages();
-
-        deflect::ImageWrapper bigImage(nullptr, 1000, 1000, deflect::ARGB);
-        bigImage.compressionPolicy = deflect::COMPRESSION_ON;
-        BOOST_CHECK_THROW(stream.send(bigImage).get(), std::invalid_argument);
-    }
-
-    // handle close of streamer
-    processServerMessages();
-
-    serverThread.quit();
-    serverThread.wait();
+    deflect::ImageWrapper bigImage(nullptr, 1000, 1000, deflect::ARGB);
+    bigImage.compressionPolicy = deflect::COMPRESSION_ON;
+    BOOST_CHECK_THROW(stream.send(bigImage).get(), std::invalid_argument);
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/cpp/StreamTests.cpp
+++ b/tests/cpp/StreamTests.cpp
@@ -141,7 +141,23 @@ BOOST_AUTO_TEST_CASE(testErrorOnUnsupportedUncompressedFormats)
     {
         deflect::ImageWrapper image(pixels.data(), 4, 4, format);
         image.compressionPolicy = deflect::COMPRESSION_OFF;
-        BOOST_CHECK(!stream.send(image).get());
+        BOOST_CHECK_THROW(stream.send(image).get(), std::invalid_argument);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testSuccessOnCompressedFormats)
+{
+    deflect::Stream stream("id", "dummyhost");
+    std::vector<unsigned char> pixels(4 * 4 * 4);
+
+    std::vector<deflect::PixelFormat> unsupportedUncompressedFormats = {
+        deflect::RGB, deflect::ARGB, deflect::BGR, deflect::BGRA,
+        deflect::ABGR};
+    for (const auto format : unsupportedUncompressedFormats)
+    {
+        deflect::ImageWrapper image(pixels.data(), 4, 4, format);
+        image.compressionPolicy = deflect::COMPRESSION_ON;
+        BOOST_CHECK(stream.send(image).get());
     }
 }
 
@@ -150,7 +166,7 @@ BOOST_AUTO_TEST_CASE(testErrorOnNullUncompressedImage)
     deflect::Stream stream("id", "dummyhost");
     deflect::ImageWrapper nullImage(nullptr, 4, 4, deflect::ARGB);
     nullImage.compressionPolicy = deflect::COMPRESSION_ON;
-    BOOST_CHECK(!stream.send(nullImage).get());
+    BOOST_CHECK_THROW(stream.send(nullImage).get(), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(testErrorOnInvalidJpegCompressionValues)
@@ -160,10 +176,10 @@ BOOST_AUTO_TEST_CASE(testErrorOnInvalidJpegCompressionValues)
     deflect::ImageWrapper imageWrapper(pixels.data(), 4, 4, deflect::ARGB);
     imageWrapper.compressionPolicy = deflect::COMPRESSION_ON;
     imageWrapper.compressionQuality = 0;
-    BOOST_CHECK(!stream.send(imageWrapper).get());
+    BOOST_CHECK_THROW(stream.send(imageWrapper).get(), std::invalid_argument);
 
     imageWrapper.compressionQuality = 101;
-    BOOST_CHECK(!stream.send(imageWrapper).get());
+    BOOST_CHECK_THROW(stream.send(imageWrapper).get(), std::invalid_argument);
 
     imageWrapper.compressionQuality = 1;
     BOOST_CHECK(stream.send(imageWrapper).get());

--- a/tests/mock/CMakeLists.txt
+++ b/tests/mock/CMakeLists.txt
@@ -6,16 +6,21 @@
 # Generates a mock library used by the cpp unit tests.
 
 set(DEFLECTMOCK_HEADERS
+  DeflectServer.h
   MinimalGlobalQtApp.h
+  MinimalDeflectServer.h
   MockServer.h
   Timer.h
 )
 
 set(DEFLECTMOCK_SOURCES
+  DeflectServer.cpp
+  MinimalDeflectServer.cpp
   MockServer.cpp
 )
 
-set(DEFLECTMOCK_LINK_LIBRARIES Qt5::Core Qt5::Network)
+set(DEFLECTMOCK_LINK_LIBRARIES Deflect ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+  Qt5::Core Qt5::Network)
 
 set(DEFLECTMOCK_INCLUDE_NAME deflect/mock)
 set(DEFLECTMOCK_OMIT_LIBRARY_HEADER ON)

--- a/tests/mock/DeflectServer.cpp
+++ b/tests/mock/DeflectServer.cpp
@@ -1,0 +1,142 @@
+/*********************************************************************/
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Daniel.Nachbaur@epfl.ch                       */
+/* All rights reserved.                                              */
+/*                                                                   */
+/* Redistribution and use in source and binary forms, with or        */
+/* without modification, are permitted provided that the following   */
+/* conditions are met:                                               */
+/*                                                                   */
+/*   1. Redistributions of source code must retain the above         */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer.                                                  */
+/*                                                                   */
+/*   2. Redistributions in binary form must reproduce the above      */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer in the documentation and/or other materials       */
+/*      provided with the distribution.                              */
+/*                                                                   */
+/*    THIS  SOFTWARE IS PROVIDED  BY THE  UNIVERSITY OF  TEXAS AT    */
+/*    AUSTIN  ``AS IS''  AND ANY  EXPRESS OR  IMPLIED WARRANTIES,    */
+/*    INCLUDING, BUT  NOT LIMITED  TO, THE IMPLIED  WARRANTIES OF    */
+/*    MERCHANTABILITY  AND FITNESS FOR  A PARTICULAR  PURPOSE ARE    */
+/*    DISCLAIMED.  IN  NO EVENT SHALL THE UNIVERSITY  OF TEXAS AT    */
+/*    AUSTIN OR CONTRIBUTORS BE  LIABLE FOR ANY DIRECT, INDIRECT,    */
+/*    INCIDENTAL,  SPECIAL, EXEMPLARY,  OR  CONSEQUENTIAL DAMAGES    */
+/*    (INCLUDING, BUT  NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE    */
+/*    GOODS  OR  SERVICES; LOSS  OF  USE,  DATA,  OR PROFITS;  OR    */
+/*    BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF    */
+/*    LIABILITY, WHETHER  IN CONTRACT, STRICT  LIABILITY, OR TORT    */
+/*    (INCLUDING NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT    */
+/*    OF  THE  USE OF  THIS  SOFTWARE,  EVEN  IF ADVISED  OF  THE    */
+/*    POSSIBILITY OF SUCH DAMAGE.                                    */
+/*                                                                   */
+/* The views and conclusions contained in the software and           */
+/* documentation are those of the authors and should not be          */
+/* interpreted as representing official policies, either expressed   */
+/* or implied, of The University of Texas at Austin.                 */
+/*********************************************************************/
+
+#include "DeflectServer.h"
+
+#include <boost/test/unit_test.hpp>
+
+DeflectServer::DeflectServer()
+{
+    _server = new deflect::Server(0 /* OS-chosen port */);
+    _server->moveToThread(&_thread);
+    _thread.connect(&_thread, &QThread::finished, _server,
+                    &deflect::Server::deleteLater);
+    _thread.start();
+
+    _server->connect(_server, &deflect::Server::pixelStreamOpened,
+                     [&](const QString) {
+                         ++_openedStreams;
+                         _mutex.lock();
+                         _receivedState = true;
+                         _received.wakeAll();
+                         _mutex.unlock();
+                     });
+
+    _server->connect(_server, &deflect::Server::pixelStreamClosed,
+                     [&](const QString) {
+                         --_openedStreams;
+                         _mutex.lock();
+                         _receivedState = true;
+                         _received.wakeAll();
+                         _mutex.unlock();
+                     });
+
+    _server->connect(_server, &deflect::Server::receivedSizeHints,
+                     [&](const QString id, const deflect::SizeHints hints) {
+                         if (_sizeHintsCallback)
+                             _sizeHintsCallback(id, hints);
+                         _mutex.lock();
+                         _receivedState = true;
+                         _received.wakeAll();
+                         _mutex.unlock();
+                     });
+
+    _server->connect(_server, &deflect::Server::receivedData,
+                     [&](const QString id, QByteArray data) {
+                         if (_dataReceivedCallback)
+                             _dataReceivedCallback(id, data);
+                         _mutex.lock();
+                         _receivedState = true;
+                         _received.wakeAll();
+                         _mutex.unlock();
+                     });
+
+    _server->connect(_server, &deflect::Server::receivedFrame,
+                     [&](deflect::FramePtr frame) {
+                         if (_frameReceivedCallback)
+                             _frameReceivedCallback(frame);
+                         ++_receivedFrames;
+                         _mutex.lock();
+                         _receivedState = true;
+                         _received.wakeAll();
+                         _mutex.unlock();
+                     });
+
+    _server->connect(_server, &deflect::Server::registerToEvents,
+                     [&](const QString id, const bool exclusive,
+                         deflect::EventReceiver* evtReceiver,
+                         deflect::BoolPromisePtr success) {
+
+                         if (_registerToEventsCallback)
+                             _registerToEventsCallback(id, exclusive,
+                                                       evtReceiver);
+
+                         _eventReceiver = evtReceiver;
+                         success->set_value(true);
+                     });
+}
+
+DeflectServer::~DeflectServer()
+{
+    _thread.quit();
+    _thread.wait();
+}
+
+void DeflectServer::waitForMessage()
+{
+    for (size_t j = 0; j < 20; ++j)
+    {
+        _mutex.lock();
+        _received.wait(&_mutex, 100 /*ms*/);
+        if (_receivedState)
+        {
+            _mutex.unlock();
+            break;
+        }
+        _mutex.unlock();
+    }
+    BOOST_CHECK(_receivedState);
+    _receivedState = false;
+}
+
+void DeflectServer::processEvent(const deflect::Event& event)
+{
+    BOOST_REQUIRE(_eventReceiver);
+    _eventReceiver->processEvent(event);
+}

--- a/tests/mock/MinimalDeflectServer.h
+++ b/tests/mock/MinimalDeflectServer.h
@@ -1,6 +1,6 @@
 /*********************************************************************/
-/* Copyright (c) 2013, EPFL/Blue Brain Project                       */
-/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Daniel.Nachbaur@epfl.ch                       */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
@@ -37,40 +37,23 @@
 /* or implied, of The University of Texas at Austin.                 */
 /*********************************************************************/
 
-#define BOOST_TEST_MODULE Socket
-#include <boost/test/unit_test.hpp>
-namespace ut = boost::unit_test;
+#ifndef DEFLECT_MINIMAL_DEFLECTSERVER_H
+#define DEFLECT_MINIMAL_DEFLECTSERVER_H
 
-#include "MinimalDeflectServer.h"
-#include "MinimalGlobalQtApp.h"
+#include "MockServer.h"
 
-#include <deflect/Socket.h>
+#include <QThread>
 
-BOOST_GLOBAL_FIXTURE(MinimalGlobalQtApp);
-
-void testSocketConnect(const int32_t versionOffset)
+class MinimalDeflectServer
 {
-    MinimalDeflectServer server(versionOffset);
+public:
+    explicit MinimalDeflectServer(int32_t versionOffset = 0);
+    ~MinimalDeflectServer();
 
-    deflect::Socket socket("localhost", server.serverPort());
+    quint16 serverPort() const { return _server->serverPort(); }
+private:
+    QThread _thread;
+    MockServer* _server;
+};
 
-    BOOST_CHECK(socket.isConnected() == (versionOffset >= 0));
-}
-
-BOOST_AUTO_TEST_CASE(
-    testSocketConnectionValidWhenReturnedCorrectNetworkProtocolVersion)
-{
-    testSocketConnect(0);
-}
-
-BOOST_AUTO_TEST_CASE(
-    testSocketConnectionInvalidWhenReturnedLowerNetworkProtocolVersion)
-{
-    testSocketConnect(-1);
-}
-
-BOOST_AUTO_TEST_CASE(
-    testSocketConnectionInvalidWhenReturnedHigherNetworkProtocolVersion)
-{
-    testSocketConnect(1);
-}
+#endif


### PR DESCRIPTION
* Throw on failed connection to server in stream ctor; refactor test deflect servers
* Transform error message printing into exceptions
* Catch errors regarding invalid JPEG quality values
* Allow uncompressed small tile sending
* Move sendSizeHints and sendData also to Observer