### PR TITLE
Support for streaming images in OpenGL format (bottom-up row order)

### DIFF
--- a/apps/SimpleStreamer/main.cpp
+++ b/apps/SimpleStreamer/main.cpp
@@ -254,9 +254,6 @@ struct Image
         image.data.resize(image.width * image.height * 4);
         glReadPixels(0, 0, image.width, image.height, GL_RGBA, GL_UNSIGNED_BYTE,
                      (GLvoid*)image.data.data());
-
-        deflect::ImageWrapper::swapYAxis(image.data.data(), image.width,
-                                         image.height, 4);
         return image;
     }
 
@@ -292,6 +289,7 @@ bool send(const Image& image, const deflect::View view)
                                          : deflect::COMPRESSION_OFF;
     deflectImage.compressionQuality = deflectCompressionQuality;
     deflectImage.view = view;
+    deflectImage.rowOrder = deflect::RowOrder::bottom_up;
     return deflectStream->send(deflectImage).get();
 }
 

--- a/deflect/CMakeLists.txt
+++ b/deflect/CMakeLists.txt
@@ -29,6 +29,7 @@ set(DEFLECT_HEADERS
   Socket.h
   SourceBuffer.h
   StreamPrivate.h
+  TaskBuilder.h
 )
 
 set(DEFLECT_SOURCES
@@ -48,6 +49,7 @@ set(DEFLECT_SOURCES
   Stream.cpp
   StreamPrivate.cpp
   StreamSendWorker.cpp
+  TaskBuilder.cpp
 )
 
 set(DEFLECT_LINK_LIBRARIES PRIVATE Qt5::Concurrent Qt5::Core Qt5::Network)

--- a/deflect/Frame.cpp
+++ b/deflect/Frame.cpp
@@ -45,14 +45,30 @@ QSize Frame::computeDimensions() const
 {
     QSize size(0, 0);
 
-    for (size_t i = 0; i < segments.size(); ++i)
+    for (const auto& segment : segments)
     {
-        const deflect::SegmentParameters& params = segments[i].parameters;
+        const auto& params = segment.parameters;
         size.setWidth(std::max(size.width(), (int)(params.width + params.x)));
         size.setHeight(
             std::max(size.height(), (int)(params.height + params.y)));
     }
 
     return size;
+}
+
+RowOrder Frame::determineRowOrder() const
+{
+    if (segments.empty())
+        throw std::runtime_error("frame has no segements");
+
+    const auto frameRowOrder = segments[0].rowOrder;
+
+    for (const auto& segment : segments)
+    {
+        if (segment.rowOrder != frameRowOrder)
+            throw std::runtime_error("frame has incoherent row orders");
+    }
+
+    return frameRowOrder;
 }
 }

--- a/deflect/Frame.h
+++ b/deflect/Frame.h
@@ -63,6 +63,12 @@ public:
 
     /** Get the total dimensions of this frame. */
     DEFLECT_API QSize computeDimensions() const;
+
+    /**
+     * @return the row order of all frame segments
+     * @throws std::runtime_error if not all segments have the same RowOrder
+     */
+    DEFLECT_API RowOrder determineRowOrder() const;
 };
 }
 

--- a/deflect/FrameDispatcher.h
+++ b/deflect/FrameDispatcher.h
@@ -58,7 +58,7 @@ class FrameDispatcher : public QObject
 
 public:
     /** Construct a dispatcher */
-    FrameDispatcher(QObject* parent);
+    FrameDispatcher(QObject* parent = nullptr);
 
     /** Destructor. */
     ~FrameDispatcher();
@@ -143,6 +143,14 @@ signals:
     void pixelStreamOpened(QString uri);
 
     /**
+     * Notify that an exception occured and the stream should be closed.
+     *
+     * @param uri Identifier for the stream
+     * @param what The description of the exception that occured
+     */
+    void pixelStreamException(QString uri, QString what);
+
+    /**
      * Notify that a pixel stream has been closed.
      *
      * @param uri Identifier for the stream
@@ -155,13 +163,6 @@ signals:
      * @param frame The latest frame available for a stream
      */
     void sendFrame(deflect::FramePtr frame);
-
-    /**
-     * Notify that a pixel stream has exceeded its maximum allowed size.
-     *
-     * @param uri Identifier for the stream
-     */
-    void bufferSizeExceeded(QString uri);
 
 private:
     class Impl;

--- a/deflect/ImageSegmenter.cpp
+++ b/deflect/ImageSegmenter.cpp
@@ -62,7 +62,7 @@ bool _isOnRightSideOfSideBySideImage(const Segment& segment)
 }
 }
 
-bool ImageSegmenter::generate(const ImageWrapper& image, const Handler& handler)
+bool ImageSegmenter::generate(const ImageWrapper& image, Handler handler)
 {
     if (image.compressionPolicy == COMPRESSION_ON)
         return _generateJpeg(image, handler);
@@ -240,6 +240,7 @@ Segments ImageSegmenter::_generateSegments(const ImageWrapper& image) const
         segment.view =
             image.view == View::side_by_side ? View::left_eye : image.view;
         segment.sourceImage = &image;
+        segment.rowOrder = image.rowOrder;
         segments.push_back(segment);
     }
 

--- a/deflect/ImageSegmenter.h
+++ b/deflect/ImageSegmenter.h
@@ -75,8 +75,7 @@ public:
      * @return true if all image handlers returned true, false on failure
      * @see setNominalSegmentDimensions()
      */
-    DEFLECT_API bool generate(const ImageWrapper& image,
-                              const Handler& handler);
+    DEFLECT_API bool generate(const ImageWrapper& image, Handler handler);
 
     /**
      * Set the nominal segment dimensions.

--- a/deflect/ImageWrapper.h
+++ b/deflect/ImageWrapper.h
@@ -138,6 +138,22 @@ struct ImageWrapper
     View view = View::mono;
 
     /**
+     * The order of the image's data rows in memory.
+     *
+     * Set this value to bottom_up if the image data is stored following the
+     * OpenGL convention.
+     *
+     * All images that form a frame (possibly from multiple Streams) must have
+     * the same row order, otherwise the frame is invalid. This is because the
+     * frame's segments need to be reordered in addtion to flipping them
+     * individually.
+     *
+     * This is an alternative to calling swapYAxis() before sending.
+     * @version 1.7
+     */
+    RowOrder rowOrder = RowOrder::top_down;
+
+    /**
      * Get the number of bytes per pixel based on the pixelFormat.
      * @version 1.0
      */

--- a/deflect/Observer.cpp
+++ b/deflect/Observer.cpp
@@ -100,7 +100,7 @@ bool Observer::registerForEvents(const bool exclusive)
         return true;
 
     // Send the bind message
-    if (!_impl->sendWorker.enqueueBindRequest(exclusive).get())
+    if (!_impl->bindEvents(exclusive).get())
     {
         std::cerr << "deflect::Stream::registerForEvents: sending bind message "
                   << "failed" << std::endl;
@@ -175,13 +175,11 @@ void Observer::setDisconnectedCallback(const std::function<void()> callback)
 
 void Observer::sendSizeHints(const SizeHints& hints)
 {
-    _impl->sendWorker.enqueueSizeHints(hints);
+    _impl->send(hints);
 }
 
 bool Observer::sendData(const char* data, const size_t count)
 {
-    return _impl->sendWorker
-        .enqueueData(QByteArray::fromRawData(data, int(count)))
-        .get();
+    return _impl->send(QByteArray::fromRawData(data, int(count))).get();
 }
 }

--- a/deflect/Segment.h
+++ b/deflect/Segment.h
@@ -1,5 +1,5 @@
 /*********************************************************************/
-/* Copyright (c) 2013-2016, EPFL/Blue Brain Project                  */
+/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
 /*                          Raphael Dumusc <raphael.dumusc@epfl.ch>  */
 /* All rights reserved.                                              */
 /*                                                                   */
@@ -60,6 +60,8 @@ struct Segment
 
     /** Image data of the segment. */
     QByteArray imageData;
+
+    RowOrder rowOrder = RowOrder::top_down; //!< imageData row order
 
     /** @internal raw, uncompressed source image, used for compression */
     const ImageWrapper* sourceImage = nullptr;

--- a/deflect/Server.cpp
+++ b/deflect/Server.cpp
@@ -83,8 +83,11 @@ Server::Server(const int port)
             &Server::pixelStreamClosed);
     connect(_impl->frameDispatcher, &FrameDispatcher::sendFrame, this,
             &Server::receivedFrame);
-    connect(_impl->frameDispatcher, &FrameDispatcher::bufferSizeExceeded, this,
-            &Server::closePixelStream);
+    connect(_impl->frameDispatcher, &FrameDispatcher::pixelStreamException,
+            [this](const QString uri, const QString what) {
+                emit pixelStreamException(uri, what);
+                closePixelStream(uri);
+            });
 }
 
 Server::~Server()

--- a/deflect/Server.h
+++ b/deflect/Server.h
@@ -106,6 +106,16 @@ signals:
     void pixelStreamOpened(QString uri);
 
     /**
+     * Notify that a stream has encountered an exception and will be closed.
+     *
+     * Used for error reporting.
+     *
+     * @param uri Identifier for the stream
+     * @param what The error message
+     */
+    void pixelStreamException(QString uri, QString what);
+
+    /**
      * Notify that a pixel stream has been closed.
      *
      * @param uri Identifier for the stream

--- a/deflect/ServerWorker.h
+++ b/deflect/ServerWorker.h
@@ -106,6 +106,7 @@ private:
     QQueue<Event> _events;
 
     View _activeView;
+    RowOrder _activeRowOrder;
 
     void _receiveMessage();
     MessageHeader _receiveMessageHeader();

--- a/deflect/Stream.cpp
+++ b/deflect/Stream.cpp
@@ -61,16 +61,16 @@ Stream::~Stream()
 
 Stream::Future Stream::send(const ImageWrapper& image)
 {
-    return _impl->sendWorker.enqueueImage(image, false);
+    return _impl->sendImage(image, false);
 }
 
 Stream::Future Stream::finishFrame()
 {
-    return _impl->sendWorker.enqueueFinish();
+    return _impl->sendFinishFrame();
 }
 
 Stream::Future Stream::sendAndFinish(const ImageWrapper& image)
 {
-    return _impl->sendWorker.enqueueImage(image, true);
+    return _impl->sendImage(image, true);
 }
 }

--- a/deflect/StreamPrivate.h
+++ b/deflect/StreamPrivate.h
@@ -42,8 +42,10 @@
 #ifndef DEFLECT_STREAMPRIVATE_H
 #define DEFLECT_STREAMPRIVATE_H
 
+#include "ImageSegmenter.h"   // member
 #include "Socket.h"           // member
 #include "StreamSendWorker.h" // member
+#include "TaskBuilder.h"      // member
 
 #include <functional>
 #include <string>
@@ -82,6 +84,20 @@ public:
 
     /** The worker doing all the socket send operations. */
     StreamSendWorker sendWorker;
+
+    /** Prepare tasks for the sendWorker. */
+    TaskBuilder task;
+
+    /** The segmenter for doing multithreaded image segmentation + send. */
+    ImageSegmenter _imageSegmenter;
+
+    Stream::Future bindEvents(bool exclusive);
+    Stream::Future send(const SizeHints& hints);
+    Stream::Future send(QByteArray&& data);
+    Stream::Future sendImage(const ImageWrapper& image, bool finish);
+    Stream::Future sendSingleSegment(Segment&& segment, RowOrder orientation,
+                                     bool finish);
+    Stream::Future sendFinishFrame();
 };
 }
 #endif

--- a/deflect/TaskBuilder.h
+++ b/deflect/TaskBuilder.h
@@ -1,7 +1,8 @@
 /*********************************************************************/
-/* Copyright (c) 2013-2017, EPFL/Blue Brain Project                  */
-/*                          Raphael.Dumusc@epfl.ch                   */
-/*                          Daniel.Nachbaur@epfl.ch                  */
+/* Copyright (c) 2017, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* All rights reserved.                                              */
+/*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */
 /* without modification, are permitted provided that the following   */
 /* conditions are met:                                               */
@@ -33,81 +34,43 @@
 /* The views and conclusions contained in the software and           */
 /* documentation are those of the authors and should not be          */
 /* interpreted as representing official policies, either expressed   */
-/* or implied, of The University of Texas at Austin.                 */
+/* or implied, of Ecole polytechnique federale de Lausanne.          */
 /*********************************************************************/
 
-#ifndef DEFLECT_MESSAGE_HEADER_H
-#define DEFLECT_MESSAGE_HEADER_H
+#ifndef DEFLECT_TASKBUILDER_H
+#define DEFLECT_TASKBUILDER_H
 
-#include <deflect/api.h>
-
-#ifdef _WIN32
-typedef unsigned __int32 uint32_t;
-#else
-#include <stdint.h>
-#endif
-
-#include <string>
-
-class QDataStream;
+#include "StreamSendWorker.h"
+#include "types.h"
 
 namespace deflect
 {
-/** The message types. */
-enum MessageType
+/**
+ * Create tasks to be executed asynchrounously by the StreamSendWorker.
+ */
+class TaskBuilder
 {
-    MESSAGE_TYPE_NONE = 0,
-    MESSAGE_TYPE_PIXELSTREAM_OPEN = 3,
-    MESSAGE_TYPE_PIXELSTREAM_FINISH_FRAME = 4,
-    MESSAGE_TYPE_PIXELSTREAM = 5,
-    MESSAGE_TYPE_BIND_EVENTS = 6,
-    MESSAGE_TYPE_BIND_EVENTS_EX = 7,
-    MESSAGE_TYPE_BIND_EVENTS_REPLY = 8,
-    MESSAGE_TYPE_EVENT = 9,
-    MESSAGE_TYPE_QUIT = 12,
-    MESSAGE_TYPE_SIZE_HINTS = 13,
-    MESSAGE_TYPE_DATA = 14,
-    MESSAGE_TYPE_IMAGE_VIEW = 15,
-    MESSAGE_TYPE_OBSERVER_OPEN = 16,
-    MESSAGE_TYPE_IMAGE_ROW_ORDER = 17
-};
+public:
+    explicit TaskBuilder(StreamSendWorker* worker);
 
-#define MESSAGE_HEADER_URI_LENGTH 64
+    Task openStream();
+    Task openObserver();
+    Task bindEvents(bool exclusive);
+    Task close();
 
-/** Fixed-size message header. */
-struct MessageHeader
-{
-    /** Message type. */
-    MessageType type;
+    Task send(const SizeHints& hints);
+    Task send(const QByteArray& data);
+    Task send(Segment&& segment);
+    std::vector<Task> sendUsingMTCompression(const ImageWrapper& image,
+                                             ImageSegmenter& imageSegmenter,
+                                             bool finish);
+    Task finishFrame();
 
-    /** Size of the message payload. */
-    uint32_t size;
+private:
+    StreamSendWorker* _worker = nullptr;
 
-    /**
-     * Optional URI related to message.
-     * @note Needs to be of fixed size so that sizeof(MessageHeader) is constant
-     */
-    char uri[MESSAGE_HEADER_URI_LENGTH];
-
-    /** Construct a default message header */
-    DEFLECT_API MessageHeader();
-
-    /** Construct a message header with a uri */
-    DEFLECT_API MessageHeader(const MessageType type, const uint32_t size,
-                              const std::string& streamUri = "");
-
-    /** The size of the QDataStream serialized output. */
-    static const size_t serializedSize;
+    Task send(const ImageWrapper& image, ImageSegmenter& imageSegmenter);
 };
 }
-
-/**
- * Serialization for network, where sizeof(MessageHeader) can differ between
- * compilers.
- */
-DEFLECT_API QDataStream& operator<<(QDataStream& out,
-                                    const deflect::MessageHeader& header);
-DEFLECT_API QDataStream& operator>>(QDataStream& in,
-                                    deflect::MessageHeader& header);
 
 #endif

--- a/deflect/types.h
+++ b/deflect/types.h
@@ -66,6 +66,13 @@ enum class ChromaSubsampling
     YUV420  /**< 50% vertical + horizontal sub-sampling */
 };
 
+/** Row order for images memory layout. */
+enum class RowOrder
+{
+    top_down, /**< Standard image with (0,0) at the top-left corner. */
+    bottom_up /**< OpenGL image with (0,0) at the bottom-left corner. */
+};
+
 /** Cast an enum class value to its underlying type. */
 template <typename E>
 constexpr typename std::underlying_type<E>::type as_underlying_type(E e)
@@ -97,6 +104,7 @@ std::future<T> make_exception_future(Exception&& e)
 class EventReceiver;
 class Frame;
 class FrameDispatcher;
+class ImageSegmenter;
 class SegmentDecoder;
 class Server;
 class Stream;

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -5,6 +5,9 @@ Changelog {#Changelog}
 
 ### 0.14.0 (git master)
 
+* [184](https://github.com/BlueBrain/Deflect/pull/184):
+  Images in OpenGL format (bottom-up row order) can be streamed directly,
+  replacing the need for ImageWrapper::swapYAxis() in user code.
 * [179](https://github.com/BlueBrain/Deflect/pull/179):
   Added stopping() signal to qt::QuickRenderer for GL cleanup operations.
 * [177](https://github.com/BlueBrain/Deflect/pull/177):

--- a/tests/mock/CMakeLists.txt
+++ b/tests/mock/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2013-2016, EPFL/Blue Brain Project
+# Copyright (c) 2013-2017, EPFL/Blue Brain Project
 #                     Daniel Nachbaur <daniel.nachbaur@epfl.ch>
 #                     Raphael Dumusc <raphael.dumusc@epfl.ch>
 #
@@ -8,6 +8,7 @@
 set(DEFLECTMOCK_HEADERS
   boost_test_thread_safe.h
   DeflectServer.h
+  FrameUtils.h
   MinimalGlobalQtApp.h
   MinimalDeflectServer.h
   MockServer.h


### PR DESCRIPTION
Previously, such images had to be flipped by the sender using ImageWrapper::swapYAxis(). This was problematic to do in user code when the stream consisted of more that one image due to the need of mirroring the segments positions as well.