### PR TITLE
QmlStreamer bugfix: gracefully exit on Stream connection error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #                          Daniel Nachbaur <daniel.nachbaur@epfl.ch>
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-project(Deflect VERSION 0.14.0)
+project(Deflect VERSION 0.14.1)
 set(Deflect_VERSION_ABI 7)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/common)

--- a/deflect/qt/QmlStreamerImpl.h
+++ b/deflect/qt/QmlStreamerImpl.h
@@ -96,7 +96,7 @@ private:
     void _send(QKeyEvent& keyEvent);
     bool _sendToWebengineviewItems(QKeyEvent& keyEvent);
     std::string _getDeflectStreamIdentifier() const;
-    bool _setupDeflectStream();
+    void _setupDeflectStream();
 
     void _connectTouchInjector();
     void _setupMouseModeSwitcher();

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,10 @@ Changelog {#Changelog}
 
 ## Deflect 0.14
 
+### 0.14.1 (git master)
+* [192](https://github.com/BlueBrain/Deflect/pull/192):
+  QmlStreamer bugfix: gracefully exit if the stream connection fails.
+
 ### 0.14.0 (23-10-2017)
 
 * [191](https://github.com/BlueBrain/Deflect/pull/191):


### PR DESCRIPTION
A previous change made the Stream constructor throw, causing an uncaught exception.