### PR TITLE
Deflect server optimizations

### DIFF
--- a/deflect/MessageHeader.cpp
+++ b/deflect/MessageHeader.cpp
@@ -83,13 +83,7 @@ QDataStream& operator>>(QDataStream& in, deflect::MessageHeader& header)
     header.type = (deflect::MessageType)type;
     in >> size;
     header.size = size;
-
-    quint8 character;
-    for (size_t i = 0; i < MESSAGE_HEADER_URI_LENGTH; ++i)
-    {
-        in >> character;
-        header.uri[i] = (char)character;
-    }
+    in.readRawData(header.uri, MESSAGE_HEADER_URI_LENGTH);
 
     return in;
 }

--- a/deflect/Socket.cpp
+++ b/deflect/Socket.cpp
@@ -72,8 +72,9 @@ Socket::Socket(const std::string& host, const unsigned short port)
 
     _connect(host, port);
 
+    // Both objects live in the same thread, can use direct connection.
     QObject::connect(_socket, &QTcpSocket::disconnected, this,
-                     &Socket::disconnected);
+                     &Socket::disconnected, Qt::DirectConnection);
 }
 
 const std::string& Socket::getHost() const

--- a/deflect/server/Server.cpp
+++ b/deflect/server/Server.cpp
@@ -120,14 +120,17 @@ public:
                     &ServerWorker::closeConnections);
 
             // FrameDispatcher
+            // direct connection to avoid race with receivedTile in early tiles
             connect(worker, &ServerWorker::addStreamSource, frameDispatcher,
-                    &FrameDispatcher::addSource);
+                    &FrameDispatcher::addSource, Qt::DirectConnection);
             connect(frameDispatcher, &FrameDispatcher::sourceRejected, worker,
                     &ServerWorker::closeConnection);
+            // direct connection for performance
             connect(worker, &ServerWorker::receivedTile, frameDispatcher,
-                    &FrameDispatcher::processTile);
+                    &FrameDispatcher::processTile, Qt::DirectConnection);
             connect(worker, &ServerWorker::receivedFrameFinished,
-                    frameDispatcher, &FrameDispatcher::processFrameFinished);
+                    frameDispatcher, &FrameDispatcher::processFrameFinished,
+                    Qt::DirectConnection);
             connect(worker, &ServerWorker::removeStreamSource, frameDispatcher,
                     &FrameDispatcher::removeSource);
             connect(worker, &ServerWorker::addObserver, frameDispatcher,

--- a/tests/mock/DeflectServer.cpp
+++ b/tests/mock/DeflectServer.cpp
@@ -122,6 +122,12 @@ DeflectServer::~DeflectServer()
     _thread.wait();
 }
 
+void DeflectServer::requestFrame(QString uri)
+{
+    QMetaObject::invokeMethod(_server, "requestFrame",
+                              Qt::BlockingQueuedConnection, Q_ARG(QString, uri));
+}
+
 void DeflectServer::waitForMessage()
 {
     for (;;)

--- a/tests/mock/DeflectServer.h
+++ b/tests/mock/DeflectServer.h
@@ -58,7 +58,7 @@ public:
     ~DeflectServer();
 
     quint16 serverPort() const { return _server->getPort(); }
-    void requestFrame(QString uri) { _server->requestFrame(uri); }
+    void requestFrame(QString uri);
     void waitForMessage();
 
     size_t getReceivedFrames() const { return _receivedFrames; }


### PR DESCRIPTION
According to VTune, QMetaObject::activate from the emit receivedTile inside
ServerWorker::_handleMessage was hotspot #1. Using a direct connection
removes it.
The other optimization is trivial, but it was another significant hotspot.